### PR TITLE
[JENKINS-58391] Add distributionGroup parameter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ stage('Publish') {
     APPCENTER_API_TOKEN = credentials('appcenter-api-token')
   }
   steps {
-    appCenter apiToken: APPCENTER_API_TOKEN, ownerName: 'owner-name', appName: 'app-name', pathToApp: 'path/to/app.apk'
+    appCenter apiToken: APPCENTER_API_TOKEN,
+            ownerName: 'owner-name',
+            appName: 'app-name',
+            pathToApp: 'path/to/app.apk',
+            distributionGroup: 'Collaborators'
   }
 }
 ```


### PR DESCRIPTION
In #9 we forgot to add the `distributionGroup` parameter to the example in the README.