### PR TITLE
[JENKINS-58915] Raise connect timeout

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
@@ -18,12 +18,14 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 public final class AppCenterServiceFactory implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final int timeoutSeconds = 60;
 
     public static final String APPCENTER_BASE_URL = "https://api.appcenter.ms/";
 
@@ -106,7 +108,11 @@ public final class AppCenterServiceFactory implements Serializable {
         logging.setLevel(HttpLoggingInterceptor.Level.HEADERS);
 
         return new OkHttpClient.Builder()
-            .addInterceptor(logging);
+            .addInterceptor(logging)
+            .callTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .writeTimeout(timeoutSeconds, TimeUnit.SECONDS);
     }
 
     public Secret getApiToken() {

--- a/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
@@ -109,9 +109,7 @@ public final class AppCenterServiceFactory implements Serializable {
 
         return new OkHttpClient.Builder()
             .addInterceptor(logging)
-            .callTimeout(timeoutSeconds, TimeUnit.SECONDS)
             .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
-            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
             .writeTimeout(timeoutSeconds, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Upload app is fail:

> Creating an upload resource.
Upload resource successful.
Uploading app to resource.
Upload app unsuccessful.
java.net.SocketTimeoutException: timeout
io.jenkins.plugins.appcenter.AppCenterException: java.util.concurrent.ExecutionException: java.net.SocketTimeoutException: timeout
Build step 'Upload app to AppCenter' changed build result to FAILURE
Finished: FAILURE

Need rise connect timeout.