### PR TITLE
[JENKINS-58054] Add initial release notes support

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -28,6 +28,7 @@ import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import javax.annotation.Nonnull;
@@ -52,6 +53,9 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
     @Nonnull
     private final String distributionGroups;
+
+    @Nullable
+    private String releaseNotes;
 
     @Nullable
     private transient String baseUrl;
@@ -88,6 +92,16 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     @Nonnull
     public String getDistributionGroups() {
         return distributionGroups;
+    }
+
+    @Nonnull
+    public String getReleaseNotes() {
+        return Util.fixNull(releaseNotes);
+    }
+
+    @DataBoundSetter
+    public void setReleaseNotes(@Nullable String releaseNotes) {
+        this.releaseNotes = Util.fixEmpty(releaseNotes);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
@@ -18,7 +18,8 @@ final class UploadModule {
             envVars.expand(appCenterRecorder.getOwnerName()),
             envVars.expand(appCenterRecorder.getAppName()),
             envVars.expand(appCenterRecorder.getPathToApp()),
-            envVars.expand(appCenterRecorder.getDistributionGroups())
+            envVars.expand(appCenterRecorder.getDistributionGroups()),
+            envVars.expand(appCenterRecorder.getReleaseNotes())
         );
     }
 }

--- a/src/main/java/io/jenkins/plugins/appcenter/task/UploadTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/UploadTask.java
@@ -43,7 +43,7 @@ public final class UploadTask extends MasterToSlaveCallable<Boolean, AppCenterEx
                 .thenCompose(result -> createUploadResource.execute(new CreateUploadResourceTask.Request(request.ownerName, request.appName)))
                 .thenCompose(releaseUploadBeginResponse -> uploadAppToResource.execute(new UploadAppToResourceTask.Request(releaseUploadBeginResponse.upload_url, releaseUploadBeginResponse.upload_id, request.pathToApp)))
                 .thenCompose(uploadId -> commitUploadResource.execute(new CommitUploadResourceTask.Request(request.ownerName, request.appName, uploadId)))
-                .thenCompose(releaseUploadEndResponse -> distributeResource.execute(new DistributeResourceTask.Request(request.ownerName, request.appName, request.destinationGroups, releaseUploadEndResponse.release_id)))
+                .thenCompose(releaseUploadEndResponse -> distributeResource.execute(new DistributeResourceTask.Request(request.ownerName, request.appName, request.destinationGroups, request.releaseNotes, releaseUploadEndResponse.release_id)))
                 .whenComplete((releaseDetailsUpdateResponse, throwable) -> {
                     if (throwable != null) {
                         future.complete(false);

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CheckFileExistsTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CheckFileExistsTask.java
@@ -54,7 +54,7 @@ public final class CheckFileExistsTask implements AppCenterTask<Request, Boolean
 
     public static class Request {
         @Nonnull
-        public final String pathToApp;
+        private final String pathToApp;
 
         public Request(@Nonnull final String pathToApp) {
             this.pathToApp = pathToApp;

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTask.java
@@ -57,9 +57,9 @@ public final class CommitUploadResourceTask implements AppCenterTask<CommitUploa
 
     public static class Request {
         @Nonnull
-        public final String ownerName;
+        private final String ownerName;
         @Nonnull
-        public final String appName;
+        private final String appName;
         @Nonnull
         private final String uploadId;
 

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
@@ -59,9 +59,9 @@ public final class CreateUploadResourceTask implements AppCenterTask<Request, Re
 
     public static class Request {
         @Nonnull
-        public final String ownerName;
+        private final String ownerName;
         @Nonnull
-        public final String appName;
+        private final String appName;
 
         public Request(@Nonnull final String ownerName,
                        @Nonnull final String appName) {

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
@@ -43,7 +43,7 @@ public final class DistributeResourceTask implements AppCenterTask<Request, Rele
 
         final CompletableFuture<ReleaseDetailsUpdateResponse> future = new CompletableFuture<>();
 
-        final String releaseNotes = "";
+        final String releaseNotes = request.releaseNotes;
         final boolean mandatoryUpdate = false;
         final List<DestinationId> destinations = Stream.of(request.destinationGroups.split(","))
             .map(String::trim)
@@ -75,15 +75,19 @@ public final class DistributeResourceTask implements AppCenterTask<Request, Rele
         private final String appName;
         @Nonnull
         private final String destinationGroups;
+        @Nonnull
+        private final String releaseNotes;
         private final int releaseId;
 
         public Request(@Nonnull final String ownerName,
                        @Nonnull final String appName,
                        @Nonnull final String destinationGroups,
+                       @Nonnull final String releaseNotes,
                        final int releaseId) {
             this.ownerName = ownerName;
             this.appName = appName;
             this.destinationGroups = destinationGroups;
+            this.releaseNotes = releaseNotes;
             this.releaseId = releaseId;
         }
     }

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
@@ -70,9 +70,9 @@ public final class DistributeResourceTask implements AppCenterTask<Request, Rele
 
     public static class Request {
         @Nonnull
-        public final String ownerName;
+        private final String ownerName;
         @Nonnull
-        public final String appName;
+        private final String appName;
         @Nonnull
         private final String destinationGroups;
         private final int releaseId;

--- a/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
@@ -15,11 +15,14 @@ public final class UploadRequest implements Serializable {
     public final String pathToApp;
     @Nonnull
     public final String destinationGroups;
+    @Nonnull
+    public final String releaseNotes;
 
-    public UploadRequest(@Nonnull String ownerName, @Nonnull String appName, @Nonnull String pathToApp, @Nonnull String destinationGroups) {
+    public UploadRequest(@Nonnull String ownerName, @Nonnull String appName, @Nonnull String pathToApp, @Nonnull String destinationGroups, @Nonnull String releaseNotes) {
         this.ownerName = ownerName;
         this.appName = appName;
         this.pathToApp = pathToApp;
         this.destinationGroups = destinationGroups;
+        this.releaseNotes = releaseNotes;
     }
 }

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
@@ -26,4 +26,9 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Release Notes}" field="releaseNotes"
+             description="${%Optional, release notes in markdown format.}">
+        <f:textarea/>
+    </f:entry>
+
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/appcenter/ConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/ConfigurationTest.java
@@ -34,4 +34,21 @@ public class ConfigurationTest {
         // Then
         jenkinsRule.assertEqualDataBoundBeans(appCenterRecorder, configuredAppCenterRecorder);
     }
+
+    @Test
+    public void should_Configure_OptionalReleaseNotes_ViaWebForm() throws Exception {
+        // Given
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("at-this-moment-you-should-be-with-us", "janes-addiction", "ritual-de-lo-habitual", "three/days/xiola.apk", "casey, niccoli");
+        appCenterRecorder.setReleaseNotes("I miss you my dear Xiola");
+        freeStyleProject.getPublishersList().add(appCenterRecorder);
+
+        final HtmlForm htmlForm = jenkinsRule.createWebClient().getPage(freeStyleProject, "configure").getFormByName("config");
+        jenkinsRule.submit(htmlForm);
+
+        // When
+        final AppCenterRecorder configuredAppCenterRecorder = freeStyleProject.getPublishersList().get(AppCenterRecorder.class);
+
+        // Then
+        jenkinsRule.assertEqualDataBoundBeans(appCenterRecorder, configuredAppCenterRecorder);
+    }
 }

--- a/src/test/java/io/jenkins/plugins/appcenter/EnvInterpolationTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/EnvInterpolationTest.java
@@ -40,6 +40,7 @@ public class EnvInterpolationTest {
         envVars.put("APP_NAME", "ritual-de-lo-habitual");
         envVars.put("PATH_TO_APP", "three/days/xiola.apk");
         envVars.put("DISTRIBUTION_GROUPS", "casey, niccoli");
+        envVars.put("RELEASE_NOTES", "I miss you my dear Xiola");
 
         jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
 
@@ -50,6 +51,7 @@ public class EnvInterpolationTest {
             "${PATH_TO_APP}",
             "${DISTRIBUTION_GROUPS}"
         );
+        appCenterRecorder.setReleaseNotes("${RELEASE_NOTES}");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").toString());
 
         freeStyleProject.getPublishersList().add(appCenterRecorder);
@@ -113,5 +115,22 @@ public class EnvInterpolationTest {
         mockWebServer.takeRequest();
         final RecordedRequest recordedRequest = mockWebServer.takeRequest();
         assertThat(recordedRequest.getBody().readUtf8()).contains("[{\"name\":\"casey\"},{\"name\":\"niccoli\"}]");
+    }
+
+    @Test
+    public void should_InterpolateEnv_InReleaseNotes() throws Exception {
+        // Given
+        MockWebServerUtil.enqueueSuccess(mockWebServer);
+
+        // When
+        final FreeStyleBuild freeStyleBuild = freeStyleProject.scheduleBuild2(0).get();
+
+        // Then
+        jenkinsRule.assertBuildStatus(Result.SUCCESS, freeStyleBuild);
+        mockWebServer.takeRequest();
+        mockWebServer.takeRequest();
+        mockWebServer.takeRequest();
+        final RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertThat(recordedRequest.getBody().readUtf8()).contains("\"release_notes\":\"I miss you my dear Xiola\"");
     }
 }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTaskTest.java
@@ -51,7 +51,7 @@ public class DistributeResourceTaskTest {
     @Test
     public void should_ReturnResponse_When_RequestIsSuccessful() throws Exception {
         // Given
-        final DistributeResourceTask.Request request = new DistributeResourceTask.Request("owner-name", "app-name", "group1, group2", 0);
+        final DistributeResourceTask.Request request = new DistributeResourceTask.Request("owner-name", "app-name", "group1, group2", "release-notes", 0);
         final ReleaseDetailsUpdateResponse expected = new ReleaseDetailsUpdateResponse("string");
         mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\n" +
             "  \"release_notes\": \"string\"\n" +
@@ -68,7 +68,7 @@ public class DistributeResourceTaskTest {
     @Test
     public void should_ReturnException_When_RequestIsUnSuccessful() throws Exception {
         // Given
-        final DistributeResourceTask.Request request = new DistributeResourceTask.Request("owner-name", "app-name", "group1, group2", 0);
+        final DistributeResourceTask.Request request = new DistributeResourceTask.Request("owner-name", "app-name", "group1, group2", "release-notes", 0);
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
         // When


### PR DESCRIPTION
Supersedes #18 . Release note support is provided by simple text and environment substitution for now.

To add release notes use the `releaseNotes` key.

```
appCenter /*..*/,  releaseNotes: 'Some changes......' 
```