### PR TITLE
[JENKINS-59397] Increase Read Timeout to 60 seconds

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
@@ -97,6 +97,7 @@ public final class AppCenterServiceFactory implements Serializable {
             .proxy(setProxy(proxyConfiguration, httpUrl.host()))
             .proxyAuthenticator(setProxyAuthenticator(proxyConfiguration))
             .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
             .writeTimeout(timeoutSeconds, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Interestingly if you set the timeouts in the builder to `0` then there is an unlimited timeout for all properties. Not sure that is desirable though......