### PR TITLE
[JENKINS-59860] Migrate to GitHub for documentation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+# from  https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.yml
+_extends: .github
+name-template: AppCenter Plugin $NEXT_PATCH_VERSION
+tag-template: appcenter-$NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH

--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@ This plugin is currently in Alpha and looking for contributors. To begin with it
 functionality of AppCenter. When the APIs for AppCenter become stable this plugin will be eligible to be moved out of
 Alpha.
 
-Upcoming functionality:
-
-1. Specify release notes.
-2. More unit tests.
-
 ## Contributing
 
 If you would like to contribute it would be massively helpful if you followed these steps:
@@ -46,3 +41,7 @@ stage('Publish') {
 
 It may sound obvious but ensure the file you are trying to upload is available on the node that you are running the 
 plugin from.
+
+## Changelog
+
+See [release page](https://github.com/jenkinsci/appcenter-plugin/releases).

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         </developer>
     </developers>
 
-    <url>https://wiki.jenkins.io/display/JENKINS/App+Center+Plugin</url>
+    <url>https://github.com/jenkinsci/appcenter-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
Migrates the documentation to Github and the changelog to Github Releases with the help of [Release Drafter](https://github.com/toolmantim/release-drafter/).