### PR TITLE
[JENKINS-58490] Support symbol files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
         </dependency>
 
         <dependency>
+            <groupId>net.dongliu</groupId>
+            <artifactId>apk-parser</artifactId>
+            <version>2.6.9</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -22,6 +22,7 @@ import io.jenkins.plugins.appcenter.validator.AppNameValidator;
 import io.jenkins.plugins.appcenter.validator.DistributionGroupsValidator;
 import io.jenkins.plugins.appcenter.validator.PathPlaceholderValidator;
 import io.jenkins.plugins.appcenter.validator.PathToAppValidator;
+import io.jenkins.plugins.appcenter.validator.PathToDebugSymbolsValidator;
 import io.jenkins.plugins.appcenter.validator.UsernameValidator;
 import io.jenkins.plugins.appcenter.validator.Validator;
 import jenkins.model.Jenkins;
@@ -58,6 +59,9 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     private String releaseNotes;
 
     private boolean notifyTesters = true;
+
+    @Nullable
+    private String pathToDebugSymbols;
 
     @Nullable
     private transient String baseUrl;
@@ -105,6 +109,11 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
         return notifyTesters;
     }
 
+    @Nonnull
+    public String getPathToDebugSymbols() {
+        return Util.fixNull(pathToDebugSymbols);
+    }
+
     @DataBoundSetter
     public void setReleaseNotes(@Nullable String releaseNotes) {
         this.releaseNotes = Util.fixEmpty(releaseNotes);
@@ -113,6 +122,11 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     @DataBoundSetter
     public void setNotifyTesters(boolean notifyTesters) {
         this.notifyTesters = notifyTesters;
+    }
+
+    @DataBoundSetter
+    public void setPathToDebugSymbols(@Nullable String pathToDebugSymbols) {
+        this.pathToDebugSymbols = Util.fixEmpty(pathToDebugSymbols);
     }
 
     /**
@@ -231,6 +245,29 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
             if (!validator.isValid(value)) {
                 return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidDistributionGroups());
+            }
+
+            return FormValidation.ok();
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckPathToDebugSymbols(@QueryParameter String value) {
+
+
+            if (value.isEmpty()) {
+                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_missingPathToDebugSymbols());
+            }
+
+            final Validator pathToAppValidator = new PathToDebugSymbolsValidator();
+
+            if (!pathToAppValidator.isValid(value)) {
+                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidPath());
+            }
+
+            final Validator pathPlaceholderValidator = new PathPlaceholderValidator();
+
+            if (!pathPlaceholderValidator.isValid(value)) {
+                return FormValidation.warning(Messages.AppCenterRecorder_DescriptorImpl_warnings_mustNotStartWithEnvVar());
             }
 
             return FormValidation.ok();

--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -252,10 +252,8 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
         @SuppressWarnings("unused")
         public FormValidation doCheckPathToDebugSymbols(@QueryParameter String value) {
-
-
-            if (value.isEmpty()) {
-                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_missingPathToDebugSymbols());
+            if (value.trim().isEmpty()) {
+                return FormValidation.ok();
             }
 
             final Validator pathToAppValidator = new PathToDebugSymbolsValidator();

--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -209,7 +209,7 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
             final Validator pathToAppValidator = new PathToAppValidator();
 
             if (!pathToAppValidator.isValid(value)) {
-                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidPathToApp());
+                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidPath());
             }
 
             final Validator pathPlaceholderValidator = new PathPlaceholderValidator();

--- a/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterService.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterService.java
@@ -6,6 +6,10 @@ import io.jenkins.plugins.appcenter.model.appcenter.ReleaseUploadBeginRequest;
 import io.jenkins.plugins.appcenter.model.appcenter.ReleaseUploadBeginResponse;
 import io.jenkins.plugins.appcenter.model.appcenter.ReleaseUploadEndRequest;
 import io.jenkins.plugins.appcenter.model.appcenter.ReleaseUploadEndResponse;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginResponse;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadEndRequest;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadEndResponse;
 import retrofit2.http.Body;
 import retrofit2.http.PATCH;
 import retrofit2.http.POST;
@@ -39,4 +43,17 @@ public interface AppCenterService {
         @Path("app_name") String appName,
         @Path("release_id") int releaseId,
         @Body ReleaseDetailsUpdateRequest releaseDetailsUpdateRequest);
+
+    @POST("v0.1/apps/{owner_name}/{app_name}/symbol_uploads")
+    CompletableFuture<SymbolUploadBeginResponse> symbolUploadBegin(
+        @Path("owner_name") String user,
+        @Path("app_name") String appName,
+        @Body SymbolUploadBeginRequest symbolUploadBeginRequest);
+
+    @PATCH("v0.1/apps/{owner_name}/{app_name}/symbol_uploads/{symbol_upload_id}")
+    CompletableFuture<SymbolUploadEndResponse> symbolsUploadEnd(
+        @Path("owner_name") String user,
+        @Path("app_name") String appName,
+        @Path("symbol_upload_id") String uploadId,
+        @Body SymbolUploadEndRequest symbolUploadEndRequest);
 }

--- a/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterService.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterService.java
@@ -51,7 +51,7 @@ public interface AppCenterService {
         @Body SymbolUploadBeginRequest symbolUploadBeginRequest);
 
     @PATCH("v0.1/apps/{owner_name}/{app_name}/symbol_uploads/{symbol_upload_id}")
-    CompletableFuture<SymbolUploadEndResponse> symbolsUploadEnd(
+    CompletableFuture<SymbolUploadEndResponse> symbolUploadEnd(
         @Path("owner_name") String user,
         @Path("app_name") String appName,
         @Path("symbol_upload_id") String uploadId,

--- a/src/main/java/io/jenkins/plugins/appcenter/api/UploadService.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/UploadService.java
@@ -1,8 +1,12 @@
 package io.jenkins.plugins.appcenter.api;
 
 import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
+import retrofit2.http.Body;
+import retrofit2.http.Headers;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Part;
 import retrofit2.http.Url;
 
@@ -13,4 +17,9 @@ public interface UploadService {
     @Multipart
     @POST
     CompletableFuture<Void> uploadApp(@Url String url, @Part MultipartBody.Part file);
+
+    @Headers("x-ms-blob-type: BlockBlob")
+    @PUT
+    CompletableFuture<Void> uploadSymbols(@Url String url, @Body RequestBody file);
+
 }

--- a/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
@@ -21,6 +21,7 @@ final class UploadModule {
             .setDestinationGroups(envVars.expand(appCenterRecorder.getDistributionGroups()))
             .setReleaseNotes(envVars.expand(appCenterRecorder.getReleaseNotes()))
             .setNotifyTesters(appCenterRecorder.getNotifyTesters())
+            .setPathToDebugSymbols(envVars.expand(appCenterRecorder.getPathToDebugSymbols()))
             .build();
     }
 }

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/Origin.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/Origin.java
@@ -1,0 +1,6 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+public enum Origin {
+    User,
+    System
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/Status.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/Status.java
@@ -1,6 +1,10 @@
 package io.jenkins.plugins.appcenter.model.appcenter;
 
 public enum Status {
+    created,
     committed,
-    aborted // TODO: find a way to not have to lowercase these fields for enums
+    aborted,
+    processing,
+    indexed,
+    failed  // TODO: find a way to not have to lowercase these fields for enums
 }

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolType.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolType.java
@@ -1,0 +1,9 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+public enum SymbolType {
+    Apple,
+    JavaScript,
+    Breakpad,
+    AndroidProguard,
+    UWP
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginRequest.java
@@ -2,9 +2,13 @@ package io.jenkins.plugins.appcenter.model.appcenter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class SymbolUploadBeginRequest {
+public final class SymbolUploadBeginRequest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     @Nonnull
     public final SymbolType symbol_type;
     @Nullable

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginRequest.java
@@ -1,16 +1,22 @@
 package io.jenkins.plugins.appcenter.model.appcenter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 public final class SymbolUploadBeginRequest {
+    @Nonnull
     public final SymbolType symbol_type;
+    @Nullable
     public final String client_callback;
+    @Nonnull
     public final String file_name;
+    @Nonnull
     public final String build;
+    @Nonnull
     public final String version;
 
-    public SymbolUploadBeginRequest(@Nonnull SymbolType symbol_type, @Nonnull String client_callback, @Nonnull String file_name, @Nonnull String build, @Nonnull String version) {
+    public SymbolUploadBeginRequest(@Nonnull SymbolType symbol_type, @Nullable String client_callback, @Nonnull String file_name, @Nonnull String build, @Nonnull String version) {
         this.symbol_type = symbol_type;
         this.client_callback = client_callback;
         this.file_name = file_name;
@@ -35,7 +41,7 @@ public final class SymbolUploadBeginRequest {
         if (o == null || getClass() != o.getClass()) return false;
         SymbolUploadBeginRequest that = (SymbolUploadBeginRequest) o;
         return symbol_type == that.symbol_type &&
-            client_callback.equals(that.client_callback) &&
+            Objects.equals(client_callback, that.client_callback) &&
             file_name.equals(that.file_name) &&
             build.equals(that.build) &&
             version.equals(that.version);

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginRequest.java
@@ -1,0 +1,48 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class SymbolUploadBeginRequest {
+    public final SymbolType symbol_type;
+    public final String client_callback;
+    public final String file_name;
+    public final String build;
+    public final String version;
+
+    public SymbolUploadBeginRequest(@Nonnull SymbolType symbol_type, @Nonnull String client_callback, @Nonnull String file_name, @Nonnull String build, @Nonnull String version) {
+        this.symbol_type = symbol_type;
+        this.client_callback = client_callback;
+        this.file_name = file_name;
+        this.build = build;
+        this.version = version;
+    }
+
+    @Override
+    public String toString() {
+        return "SymbolUploadBeginRequest{" +
+            "symbol_type=" + symbol_type +
+            ", client_callback='" + client_callback + '\'' +
+            ", file_name='" + file_name + '\'' +
+            ", build='" + build + '\'' +
+            ", version='" + version + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SymbolUploadBeginRequest that = (SymbolUploadBeginRequest) o;
+        return symbol_type == that.symbol_type &&
+            client_callback.equals(that.client_callback) &&
+            file_name.equals(that.file_name) &&
+            build.equals(that.build) &&
+            version.equals(that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(symbol_type, client_callback, file_name, build, version);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginResponse.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadBeginResponse.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class SymbolUploadBeginResponse {
+    public final String symbol_upload_id;
+    public final String upload_url;
+    public final String expiration_date;
+
+    public SymbolUploadBeginResponse(@Nonnull String symbol_upload_id, @Nonnull String upload_url, @Nonnull String expiration_date) {
+        this.symbol_upload_id = symbol_upload_id;
+        this.upload_url = upload_url;
+        this.expiration_date = expiration_date;
+    }
+
+    @Override
+    public String toString() {
+        return "SymbolUploadBeginResponse{" +
+            "symbol_upload_id='" + symbol_upload_id + '\'' +
+            ", upload_url='" + upload_url + '\'' +
+            ", expiration_date='" + expiration_date + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SymbolUploadBeginResponse that = (SymbolUploadBeginResponse) o;
+        return symbol_upload_id.equals(that.symbol_upload_id) &&
+            upload_url.equals(that.upload_url) &&
+            expiration_date.equals(that.expiration_date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(symbol_upload_id, upload_url, expiration_date);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadEndRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadEndRequest.java
@@ -1,0 +1,32 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class SymbolUploadEndRequest {
+    public final Status status;
+
+    public SymbolUploadEndRequest(@Nonnull Status status) {
+        this.status = status;
+    }
+
+    @Override
+    public String toString() {
+        return "SymbolUploadEndRequest{" +
+            "status=" + status +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SymbolUploadEndRequest that = (SymbolUploadEndRequest) o;
+        return status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadEndResponse.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadEndResponse.java
@@ -1,0 +1,78 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+
+public final class SymbolUploadEndResponse {
+    public final String symbol_upload_id;
+    public final String app_id;
+    public final SymbolUploadUserInfo user;
+    public final Status status;
+    public final SymbolType symbol_type;
+    public final List<UploadedSymbolInfo> symbols_uploaded;
+    public final Origin origin;
+    public final String file_name;
+    public final int file_size;
+    public final String timestamp;
+
+    public SymbolUploadEndResponse(@Nonnull String symbol_upload_id,
+                                   @Nonnull String app_id,
+                                   @Nonnull SymbolUploadUserInfo user,
+                                   @Nonnull Status status,
+                                   @Nonnull SymbolType symbol_type,
+                                   @Nonnull List<UploadedSymbolInfo> symbols_uploaded,
+                                   @Nonnull Origin origin,
+                                   @Nonnull String file_name,
+                                   int file_size,
+                                   @Nonnull String timestamp) {
+        this.symbol_upload_id = symbol_upload_id;
+        this.app_id = app_id;
+        this.user = user;
+        this.status = status;
+        this.symbol_type = symbol_type;
+        this.symbols_uploaded = symbols_uploaded;
+        this.origin = origin;
+        this.file_name = file_name;
+        this.file_size = file_size;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "SymbolUploadEndResponse{" +
+            "symbol_upload_id='" + symbol_upload_id + '\'' +
+            ", app_id='" + app_id + '\'' +
+            ", user=" + user +
+            ", status=" + status +
+            ", symbol_type=" + symbol_type +
+            ", symbols_uploaded=" + symbols_uploaded +
+            ", origin=" + origin +
+            ", file_name='" + file_name + '\'' +
+            ", file_size=" + file_size +
+            ", timestamp='" + timestamp + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SymbolUploadEndResponse that = (SymbolUploadEndResponse) o;
+        return file_size == that.file_size &&
+            symbol_upload_id.equals(that.symbol_upload_id) &&
+            app_id.equals(that.app_id) &&
+            user.equals(that.user) &&
+            status == that.status &&
+            symbol_type == that.symbol_type &&
+            symbols_uploaded.equals(that.symbols_uploaded) &&
+            origin == that.origin &&
+            file_name.equals(that.file_name) &&
+            timestamp.equals(that.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(symbol_upload_id, app_id, user, status, symbol_type, symbols_uploaded, origin, file_name, file_size, timestamp);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadUserInfo.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/SymbolUploadUserInfo.java
@@ -1,0 +1,36 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class SymbolUploadUserInfo {
+    public final String email;
+    public final String display_name;
+
+    public SymbolUploadUserInfo(@Nonnull String email, @Nonnull String display_name) {
+        this.email = email;
+        this.display_name = display_name;
+    }
+
+    @Override
+    public String toString() {
+        return "SymbolUploadUserInfo{" +
+            "email='" + email + '\'' +
+            ", display_name='" + display_name + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SymbolUploadUserInfo that = (SymbolUploadUserInfo) o;
+        return email.equals(that.email) &&
+            display_name.equals(that.display_name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(email, display_name);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/UploadedSymbolInfo.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/model/appcenter/UploadedSymbolInfo.java
@@ -1,0 +1,36 @@
+package io.jenkins.plugins.appcenter.model.appcenter;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public final class UploadedSymbolInfo {
+    public final String symbol_id;
+    public final String platform;
+
+    public UploadedSymbolInfo(@Nonnull String symbol_id, @Nonnull String platform) {
+        this.symbol_id = symbol_id;
+        this.platform = platform;
+    }
+
+    @Override
+    public String toString() {
+        return "UploadedSymbolInfo{" +
+            "symbol_id='" + symbol_id + '\'' +
+            ", platform='" + platform + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UploadedSymbolInfo that = (UploadedSymbolInfo) o;
+        return symbol_id.equals(that.symbol_id) &&
+            platform.equals(that.platform);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(symbol_id, platform);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/task/UploadTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/UploadTask.java
@@ -1,10 +1,10 @@
 package io.jenkins.plugins.appcenter.task;
 
 import io.jenkins.plugins.appcenter.AppCenterException;
-import io.jenkins.plugins.appcenter.task.internal.CheckFileExistsTask;
 import io.jenkins.plugins.appcenter.task.internal.CommitUploadResourceTask;
 import io.jenkins.plugins.appcenter.task.internal.CreateUploadResourceTask;
 import io.jenkins.plugins.appcenter.task.internal.DistributeResourceTask;
+import io.jenkins.plugins.appcenter.task.internal.PrerequisitesTask;
 import io.jenkins.plugins.appcenter.task.internal.UploadAppToResourceTask;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
 import jenkins.security.MasterToSlaveCallable;
@@ -17,7 +17,7 @@ import java.util.concurrent.ExecutionException;
 @Singleton
 public final class UploadTask extends MasterToSlaveCallable<Boolean, AppCenterException> {
 
-    private final CheckFileExistsTask checkFileExists;
+    private final PrerequisitesTask prerequisitesTask;
     private final CreateUploadResourceTask createUploadResource;
     private final UploadAppToResourceTask uploadAppToResource;
     private final CommitUploadResourceTask commitUploadResource;
@@ -25,8 +25,8 @@ public final class UploadTask extends MasterToSlaveCallable<Boolean, AppCenterEx
     private final UploadRequest originalRequest;
 
     @Inject
-    UploadTask(final CheckFileExistsTask checkFileExists, final CreateUploadResourceTask createUploadResource, final UploadAppToResourceTask uploadAppToResource, final CommitUploadResourceTask commitUploadResource, final DistributeResourceTask distributeResource, final UploadRequest request) {
-        this.checkFileExists = checkFileExists;
+    UploadTask(final PrerequisitesTask prerequisitesTask, final CreateUploadResourceTask createUploadResource, final UploadAppToResourceTask uploadAppToResource, final CommitUploadResourceTask commitUploadResource, final DistributeResourceTask distributeResource, final UploadRequest request) {
+        this.prerequisitesTask = prerequisitesTask;
         this.createUploadResource = createUploadResource;
         this.uploadAppToResource = uploadAppToResource;
         this.commitUploadResource = commitUploadResource;
@@ -39,7 +39,7 @@ public final class UploadTask extends MasterToSlaveCallable<Boolean, AppCenterEx
         final CompletableFuture<Boolean> future = new CompletableFuture<>();
 
         try {
-            checkFileExists.execute(originalRequest)
+            prerequisitesTask.execute(originalRequest)
                 .thenCompose(createUploadResource::execute)
                 .thenCompose(uploadAppToResource::execute)
                 .thenCompose(commitUploadResource::execute)

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTask.java
@@ -6,6 +6,7 @@ import io.jenkins.plugins.appcenter.AppCenterLogger;
 import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
 import io.jenkins.plugins.appcenter.model.appcenter.ReleaseUploadEndRequest;
 import io.jenkins.plugins.appcenter.model.appcenter.Status;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadEndRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
 
 import javax.annotation.Nonnull;
@@ -34,7 +35,18 @@ public final class CommitUploadResourceTask implements AppCenterTask<UploadReque
     @Nonnull
     @Override
     public CompletableFuture<UploadRequest> execute(@Nonnull UploadRequest request) {
-        log("Committing resource.");
+        if (request.symbolUploadId == null) {
+            return commitAppUpload(request);
+        } else {
+            return commitAppUpload(request)
+                .thenCompose(this::commitSymbolsUpload);
+        }
+    }
+
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> commitAppUpload(@Nonnull UploadRequest request) {
+        log("Committing app resource.");
 
         final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
         final ReleaseUploadEndRequest releaseUploadEndRequest = new ReleaseUploadEndRequest(Status.committed);
@@ -43,14 +55,36 @@ public final class CommitUploadResourceTask implements AppCenterTask<UploadReque
             .releaseUploadEnd(request.ownerName, request.appName, request.uploadId, releaseUploadEndRequest)
             .whenComplete((releaseUploadBeginResponse, throwable) -> {
                 if (throwable != null) {
-                    final AppCenterException exception = logFailure("Committing resource unsuccessful: ", throwable);
+                    final AppCenterException exception = logFailure("Committing app resource unsuccessful: ", throwable);
                     future.completeExceptionally(exception);
                 } else {
-                    log("Committing resource successful.");
+                    log("Committing app resource successful.");
                     final UploadRequest uploadRequest = request.newBuilder()
                         .setReleaseId(releaseUploadBeginResponse.release_id)
                         .build();
                     future.complete(uploadRequest);
+                }
+            });
+
+        return future;
+    }
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> commitSymbolsUpload(@Nonnull UploadRequest request) {
+        log("Committing symbol resource.");
+
+        final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
+        final SymbolUploadEndRequest symbolUploadEndRequest = new SymbolUploadEndRequest(Status.committed);
+
+        factory.createAppCenterService()
+            .symbolUploadEnd(request.ownerName, request.appName, request.symbolUploadId, symbolUploadEndRequest)
+            .whenComplete((symbolUploadEndResponse, throwable) -> {
+                if (throwable != null) {
+                    final AppCenterException exception = logFailure("Committing symbol resource unsuccessful: ", throwable);
+                    future.completeExceptionally(exception);
+                } else {
+                    log("Committing symbol resource successful.");
+                    future.complete(request);
                 }
             });
 

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
@@ -4,6 +4,7 @@ import hudson.model.TaskListener;
 import io.jenkins.plugins.appcenter.AppCenterException;
 import io.jenkins.plugins.appcenter.AppCenterLogger;
 import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
 
 import javax.annotation.Nonnull;
@@ -32,7 +33,17 @@ public final class CreateUploadResourceTask implements AppCenterTask<UploadReque
     @Nonnull
     @Override
     public CompletableFuture<UploadRequest> execute(@Nonnull UploadRequest request) {
-        log("Creating an upload resource.");
+        if (request.symbolUploadRequest == null) {
+            return createUploadResourceForApp(request);
+        } else {
+            return createUploadResourceForApp(request)
+                .thenCompose(this::createUploadResourceForDebugSymbols);
+        }
+    }
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> createUploadResourceForApp(@Nonnull UploadRequest request) {
+        log("Creating an upload resource for app.");
 
         final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
 
@@ -43,13 +54,40 @@ public final class CreateUploadResourceTask implements AppCenterTask<UploadReque
             .releaseUploadBegin(request.ownerName, request.appName)
             .whenComplete((releaseUploadBeginResponse, throwable) -> {
                 if (throwable != null) {
-                    final AppCenterException exception = logFailure("Create upload resource unsuccessful: ", throwable);
+                    final AppCenterException exception = logFailure("Create upload resource for app unsuccessful: ", throwable);
                     future.completeExceptionally(exception);
                 } else {
-                    log("Create upload resource successful.");
+                    log("Create upload resource for app successful.");
                     final UploadRequest uploadRequest = request.newBuilder()
                         .setUploadUrl(releaseUploadBeginResponse.upload_url)
                         .setUploadId(releaseUploadBeginResponse.upload_id)
+                        .build();
+                    future.complete(uploadRequest);
+                }
+            });
+
+        return future;
+    }
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> createUploadResourceForDebugSymbols(@Nonnull UploadRequest request) {
+        log("Creating an upload resource for debug symbols.");
+
+        final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
+
+        final SymbolUploadBeginRequest symbolUploadRequest = request.symbolUploadRequest;
+
+        factory.createAppCenterService()
+            .symbolUploadBegin(request.ownerName, request.appName, symbolUploadRequest)
+            .whenComplete((symbolsUploadBeginResponse, throwable) -> {
+                if (throwable != null) {
+                    final AppCenterException exception = logFailure("Create upload resource for debug symbols unsuccessful: ", throwable);
+                    future.completeExceptionally(exception);
+                } else {
+                    log("Create upload resource for debug symbols successful.");
+                    final UploadRequest uploadRequest = request.newBuilder()
+                        .setSymbolUploadUrl(symbolsUploadBeginResponse.upload_url)
+                        .setSymbolUploadId(symbolsUploadBeginResponse.symbol_upload_id)
                         .build();
                     future.complete(uploadRequest);
                 }

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
@@ -7,8 +7,8 @@ import io.jenkins.plugins.appcenter.AppCenterLogger;
 import io.jenkins.plugins.appcenter.model.appcenter.SymbolType;
 import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
-import net.dongliu.apk.parser.ApkParsers;
-import net.dongliu.apk.parser.bean.ApkMeta;
+import io.jenkins.plugins.appcenter.util.AndroidParser;
+import io.jenkins.plugins.appcenter.util.ParserFactory;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -27,11 +27,14 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     private final TaskListener taskListener;
     @Nonnull
     private final FilePath filePath;
+    @Nonnull
+    private final ParserFactory parserFactory;
 
     @Inject
-    PrerequisitesTask(@Nonnull TaskListener taskListener, @Nonnull final FilePath filePath) {
+    PrerequisitesTask(@Nonnull TaskListener taskListener, @Nonnull final FilePath filePath, @Nonnull final ParserFactory parserFactory) {
         this.taskListener = taskListener;
         this.filePath = filePath;
+        this.parserFactory = parserFactory;
     }
 
     @Nonnull
@@ -113,11 +116,12 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     @Nonnull
     private SymbolUploadBeginRequest androidSymbolsUpload(@Nonnull String pathToApp) throws IOException {
         final File file = new File(filePath.child(pathToApp).getRemote());
-        final ApkMeta metaInfo = ApkParsers.getMetaInfo(file);
-        final String versionCode = metaInfo.getVersionCode().toString();
-        final String versionName = metaInfo.getVersionName();
+        final AndroidParser androidParser = parserFactory.androidParser(file);
+        final String fileName = androidParser.fileName();
+        final String versionCode = androidParser.versionCode();
+        final String versionName = androidParser.versionName();
 
-        return new SymbolUploadBeginRequest(SymbolType.AndroidProguard, null, file.getName(), versionCode, versionName);
+        return new SymbolUploadBeginRequest(SymbolType.AndroidProguard, null, fileName, versionCode, versionName);
     }
 
     @Nonnull

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
@@ -4,11 +4,16 @@ import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.appcenter.AppCenterException;
 import io.jenkins.plugins.appcenter.AppCenterLogger;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolType;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import net.dongliu.apk.parser.ApkParsers;
+import net.dongliu.apk.parser.bean.ApkMeta;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.concurrent.CompletableFuture;
@@ -32,6 +37,16 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     @Nonnull
     @Override
     public CompletableFuture<UploadRequest> execute(@Nonnull UploadRequest request) {
+        if (request.pathToDebugSymbols.trim().isEmpty()) {
+            return checkFileExists(request);
+        } else {
+            return checkFileExists(request)
+                .thenCompose(this::checkSymbolsExist);
+        }
+    }
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> checkFileExists(@Nonnull UploadRequest request) {
         final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
 
         try {
@@ -45,8 +60,9 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
                 future.completeExceptionally(exception);
             } else {
                 log(String.format("File found matching pattern: %s", request.pathToApp));
+                final String pathToApp = listOfMatchingFilePaths[0].getRemote();
                 final UploadRequest uploadRequest = request.newBuilder()
-                    .setPathToApp(listOfMatchingFilePaths[0].getRemote())
+                    .setPathToApp(pathToApp)
                     .build();
                 future.complete(uploadRequest);
             }
@@ -55,6 +71,60 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
         }
 
         return future;
+    }
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> checkSymbolsExist(@Nonnull UploadRequest request) {
+        final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
+
+        try {
+            final FilePath[] listOfMatchingFilePaths = filePath.list(request.pathToDebugSymbols);
+            final int numberOfMatchingFiles = listOfMatchingFilePaths.length;
+            if (numberOfMatchingFiles > 1) {
+                final AppCenterException exception = logFailure(String.format("Multiple symbols found matching pattern: %s", request.pathToDebugSymbols));
+                future.completeExceptionally(exception);
+            } else if (numberOfMatchingFiles < 1) {
+                final AppCenterException exception = logFailure(String.format("No symbols found matching pattern: %s", request.pathToDebugSymbols));
+                future.completeExceptionally(exception);
+            } else {
+                log(String.format("Symbols found matching pattern: %s", request.pathToDebugSymbols));
+                final String pathToDebugSymbols = listOfMatchingFilePaths[0].getRemote();
+                final UploadRequest uploadRequest = request.newBuilder()
+                    .setPathToDebugSymbols(pathToDebugSymbols)
+                    .setSymbolUploadRequest(symbolUploadRequest(request.pathToApp))
+                    .build();
+                future.complete(uploadRequest);
+            }
+        } catch (IOException | InterruptedException e) {
+            future.completeExceptionally(e);
+        }
+
+        return future;
+    }
+
+    @Nonnull
+    private SymbolUploadBeginRequest symbolUploadRequest(@Nonnull String pathToApp) throws IllegalStateException, IOException {
+        if (pathToApp.endsWith(".apk")) return androidSymbolsUpload(pathToApp);
+        if (pathToApp.endsWith(".ipa")) return appleSymbolsUpload(pathToApp);
+
+        throw new IllegalStateException("Unable to determine application type and therefore debug symbol type");
+    }
+
+    @Nonnull
+    private SymbolUploadBeginRequest androidSymbolsUpload(@Nonnull String pathToApp) throws IOException {
+        final File file = new File(filePath.child(pathToApp).getRemote());
+        final ApkMeta metaInfo = ApkParsers.getMetaInfo(file);
+        final String versionCode = metaInfo.getVersionCode().toString();
+        final String versionName = metaInfo.getVersionName();
+
+        return new SymbolUploadBeginRequest(SymbolType.AndroidProguard, null, file.getName(), versionCode, versionName);
+    }
+
+    @Nonnull
+    private SymbolUploadBeginRequest appleSymbolsUpload(@Nonnull String pathToApp) {
+        final File file = new File(filePath.child(pathToApp).getRemote());
+
+        return new SymbolUploadBeginRequest(SymbolType.Apple, null, file.getName(), "", "");
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
@@ -14,7 +14,7 @@ import java.io.PrintStream;
 import java.util.concurrent.CompletableFuture;
 
 @Singleton
-public final class CheckFileExistsTask implements AppCenterTask<UploadRequest>, AppCenterLogger {
+public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, AppCenterLogger {
 
     private static final long serialVersionUID = 1L;
 
@@ -24,7 +24,7 @@ public final class CheckFileExistsTask implements AppCenterTask<UploadRequest>, 
     private final FilePath filePath;
 
     @Inject
-    CheckFileExistsTask(@Nonnull TaskListener taskListener, @Nonnull final FilePath filePath) {
+    PrerequisitesTask(@Nonnull TaskListener taskListener, @Nonnull final FilePath filePath) {
         this.taskListener = taskListener;
         this.filePath = filePath;
     }

--- a/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.appcenter.task.request;
 
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -21,6 +23,8 @@ public final class UploadRequest implements Serializable {
     public final String releaseNotes;
 
     public final boolean notifyTesters;
+    @Nonnull
+    public final String pathToDebugSymbols;
 
     // Properties above this line are expected to be set by plugin configuration before a run they should be nonnull.
     // Properties below this line are expected to be set during a run as these values will come from AppCenter during
@@ -32,6 +36,12 @@ public final class UploadRequest implements Serializable {
     public final String uploadId;
 
     public final int releaseId;
+    @Nullable
+    public final SymbolUploadBeginRequest symbolUploadRequest;
+    @Nullable
+    public final String symbolUploadUrl;
+    @Nullable
+    public final String symbolUploadId;
 
     @Override
     public String toString() {
@@ -42,9 +52,13 @@ public final class UploadRequest implements Serializable {
             ", destinationGroups='" + destinationGroups + '\'' +
             ", releaseNotes='" + releaseNotes + '\'' +
             ", notifyTesters=" + notifyTesters +
+            ", pathToDebugSymbols='" + pathToDebugSymbols + '\'' +
             ", uploadUrl='" + uploadUrl + '\'' +
             ", uploadId='" + uploadId + '\'' +
             ", releaseId=" + releaseId +
+            ", symbolUploadRequest=" + symbolUploadRequest +
+            ", symbolUploadUrl='" + symbolUploadUrl + '\'' +
+            ", symbolUploadId='" + symbolUploadId + '\'' +
             '}';
     }
 
@@ -60,22 +74,17 @@ public final class UploadRequest implements Serializable {
             pathToApp.equals(that.pathToApp) &&
             destinationGroups.equals(that.destinationGroups) &&
             releaseNotes.equals(that.releaseNotes) &&
+            pathToDebugSymbols.equals(that.pathToDebugSymbols) &&
             Objects.equals(uploadUrl, that.uploadUrl) &&
-            Objects.equals(uploadId, that.uploadId);
+            Objects.equals(uploadId, that.uploadId) &&
+            Objects.equals(symbolUploadRequest, that.symbolUploadRequest) &&
+            Objects.equals(symbolUploadUrl, that.symbolUploadUrl) &&
+            Objects.equals(symbolUploadId, that.symbolUploadId);
     }
 
     @Override
     public int hashCode() {
-        int result = ownerName.hashCode();
-        result = 31 * result + appName.hashCode();
-        result = 31 * result + pathToApp.hashCode();
-        result = 31 * result + destinationGroups.hashCode();
-        result = 31 * result + releaseNotes.hashCode();
-        result = 31 * result + (notifyTesters ? 1 : 0);
-        result = 31 * result + (uploadUrl != null ? uploadUrl.hashCode() : 0);
-        result = 31 * result + (uploadId != null ? uploadId.hashCode() : 0);
-        result = 31 * result + releaseId;
-        return result;
+        return Objects.hash(ownerName, appName, pathToApp, destinationGroups, releaseNotes, notifyTesters, pathToDebugSymbols, uploadUrl, uploadId, releaseId, symbolUploadRequest, symbolUploadUrl, symbolUploadId);
     }
 
     private UploadRequest(Builder builder) {
@@ -85,11 +94,15 @@ public final class UploadRequest implements Serializable {
         this.destinationGroups = builder.destinationGroups;
         this.releaseNotes = builder.releaseNotes;
         this.notifyTesters = builder.notifyTesters;
+        this.pathToDebugSymbols = builder.pathToDebugSymbols;
 
         // Expected to be nullable until they are added during UploadTask.
         this.uploadUrl = builder.uploadUrl;
         this.uploadId = builder.uploadId;
         this.releaseId = builder.releaseId;
+        this.symbolUploadRequest = builder.symbolUploadRequest;
+        this.symbolUploadUrl = builder.symbolUploadUrl;
+        this.symbolUploadId = builder.symbolUploadId;
     }
 
     public Builder newBuilder() {
@@ -109,6 +122,8 @@ public final class UploadRequest implements Serializable {
         @Nonnull
         private String releaseNotes;
         private boolean notifyTesters;
+        @Nonnull
+        private String pathToDebugSymbols;
 
         // Expected to be nullable until they are added during UploadTask.
         @Nullable
@@ -116,6 +131,12 @@ public final class UploadRequest implements Serializable {
         @Nullable
         private String uploadId;
         private int releaseId;
+        @Nullable
+        private SymbolUploadBeginRequest symbolUploadRequest;
+        @Nullable
+        private String symbolUploadUrl;
+        @Nullable
+        private String symbolUploadId;
 
         public Builder() {
             ownerName = "";
@@ -124,6 +145,7 @@ public final class UploadRequest implements Serializable {
             destinationGroups = "";
             releaseNotes = "";
             notifyTesters = true;
+            pathToDebugSymbols = "";
         }
 
         Builder(@Nonnull final UploadRequest uploadRequest) {
@@ -133,11 +155,15 @@ public final class UploadRequest implements Serializable {
             this.destinationGroups = uploadRequest.destinationGroups;
             this.releaseNotes = uploadRequest.releaseNotes;
             this.notifyTesters = uploadRequest.notifyTesters;
+            this.pathToDebugSymbols = uploadRequest.pathToDebugSymbols;
 
             // Expected to be nullable until they are added during UploadTask.
             this.uploadUrl = uploadRequest.uploadUrl;
             this.uploadId = uploadRequest.uploadId;
             this.releaseId = uploadRequest.releaseId;
+            this.symbolUploadRequest = uploadRequest.symbolUploadRequest;
+            this.symbolUploadUrl = uploadRequest.symbolUploadUrl;
+            this.symbolUploadId = uploadRequest.symbolUploadId;
         }
 
         public Builder setOwnerName(@Nonnull String ownerName) {
@@ -170,6 +196,15 @@ public final class UploadRequest implements Serializable {
             return this;
         }
 
+        public Builder setPathToDebugSymbols(@Nonnull String pathToDebugSymbols) {
+            this.pathToDebugSymbols = pathToDebugSymbols;
+            return this;
+        }
+
+        // Properties above this line are expected to be set by plugin configuration before a run.
+        // Properties below this line are expected to be set during a run as these values will come
+        // from AppCenter during execution they should be nullable prior to being set.
+
         public Builder setUploadUrl(@Nonnull String uploadUrl) {
             this.uploadUrl = uploadUrl;
             return this;
@@ -182,6 +217,21 @@ public final class UploadRequest implements Serializable {
 
         public Builder setReleaseId(int releaseId) {
             this.releaseId = releaseId;
+            return this;
+        }
+
+        public Builder setSymbolUploadRequest(@Nonnull SymbolUploadBeginRequest symbolUploadRequest) {
+            this.symbolUploadRequest = symbolUploadRequest;
+            return this;
+        }
+
+        public Builder setSymbolUploadUrl(@Nonnull String symbolUploadUrl) {
+            this.symbolUploadUrl = symbolUploadUrl;
+            return this;
+        }
+
+        public Builder setSymbolUploadId(@Nonnull String symbolUploadId) {
+            this.symbolUploadId = symbolUploadId;
             return this;
         }
 

--- a/src/main/java/io/jenkins/plugins/appcenter/util/AndroidParser.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/util/AndroidParser.java
@@ -1,0 +1,45 @@
+package io.jenkins.plugins.appcenter.util;
+
+import net.dongliu.apk.parser.ApkParsers;
+import net.dongliu.apk.parser.bean.ApkMeta;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+
+public final class AndroidParser {
+
+    @Nonnull
+    private final File file;
+    @Nullable
+    private ApkMeta apkMeta;
+
+    AndroidParser(final @Nonnull File file) {
+        this.file = file;
+    }
+
+    @Nonnull
+    public String versionCode() throws IOException {
+        return metaInfo().getVersionCode().toString();
+    }
+
+    @Nonnull
+    public String versionName() throws IOException {
+        return metaInfo().getVersionName();
+    }
+
+    @Nonnull
+    public String fileName() {
+        return file.getName();
+    }
+
+    @Nonnull
+    private ApkMeta metaInfo() throws IOException {
+        if (apkMeta != null) return apkMeta;
+
+        apkMeta = ApkParsers.getMetaInfo(file);
+
+        return apkMeta;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/util/ParserFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/util/ParserFactory.java
@@ -3,8 +3,11 @@ package io.jenkins.plugins.appcenter.util;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.io.File;
+import java.io.Serializable;
 
-public final class ParserFactory {
+public final class ParserFactory implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Inject
     ParserFactory() {

--- a/src/main/java/io/jenkins/plugins/appcenter/util/ParserFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/util/ParserFactory.java
@@ -1,0 +1,17 @@
+package io.jenkins.plugins.appcenter.util;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.File;
+
+public final class ParserFactory {
+
+    @Inject
+    ParserFactory() {
+    }
+
+    @Nonnull
+    public AndroidParser androidParser(final @Nonnull File file) {
+        return new AndroidParser(file);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/appcenter/validator/PathToDebugSymbolsValidator.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/validator/PathToDebugSymbolsValidator.java
@@ -1,0 +1,15 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import hudson.Util;
+
+import javax.annotation.Nonnull;
+import java.util.function.Predicate;
+
+public final class PathToDebugSymbolsValidator extends Validator {
+
+    @Nonnull
+    @Override
+    protected Predicate<String> predicate() {
+        return Util::isRelativePath;
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
@@ -36,4 +36,9 @@
         <f:checkbox name="notifyTesters" default="true"/>
     </f:entry>
 
+    <f:entry title="${%Path To Debug Symbols}" field="pathToDebugSymbols"
+             description="${%Optional, relative path to debug symbols.}">
+        <f:textbox/>
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
@@ -8,6 +8,5 @@ AppCenterRecorder.DescriptorImpl.errors.invalidAppName=App name cannot contain w
 AppCenterRecorder.DescriptorImpl.errors.missingDistributionGroups=Please specify Distribution Groups
 AppCenterRecorder.DescriptorImpl.errors.invalidDistributionGroups=Distribution Groups cannot be empty
 AppCenterRecorder.DescriptorImpl.errors.missingPathToApp=Please specify a path to the app you wish to upload
-AppCenterRecorder.DescriptorImpl.errors.missingPathToDebugSymbols=Please specify a path to the debug symbols you wish to upload
 AppCenterRecorder.DescriptorImpl.errors.invalidPath=Invalid path
 AppCenterRecorder.DescriptorImpl.DisplayName=Upload app to AppCenter

--- a/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
@@ -8,5 +8,6 @@ AppCenterRecorder.DescriptorImpl.errors.invalidAppName=App name cannot contain w
 AppCenterRecorder.DescriptorImpl.errors.missingDistributionGroups=Please specify Distribution Groups
 AppCenterRecorder.DescriptorImpl.errors.invalidDistributionGroups=Distribution Groups cannot be empty
 AppCenterRecorder.DescriptorImpl.errors.missingPathToApp=Please specify a path to the app you wish to upload
-AppCenterRecorder.DescriptorImpl.errors.invalidPathToApp=Path must be relative
+AppCenterRecorder.DescriptorImpl.errors.missingPathToDebugSymbols=Please specify a path to the debug symbols you wish to upload
+AppCenterRecorder.DescriptorImpl.errors.invalidPath=Invalid path
 AppCenterRecorder.DescriptorImpl.DisplayName=Upload app to AppCenter

--- a/src/test/java/io/jenkins/plugins/appcenter/ConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/ConfigurationTest.java
@@ -68,4 +68,21 @@ public class ConfigurationTest {
         // Then
         jenkinsRule.assertEqualDataBoundBeans(appCenterRecorder, configuredAppCenterRecorder);
     }
+
+    @Test
+    public void should_Configure_OptionalDebugSymbols_ViaWebForm() throws Exception {
+        // Given
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("at-this-moment-you-should-be-with-us", "janes-addiction", "ritual-de-lo-habitual", "three/days/xiola.apk", "casey, niccoli");
+        appCenterRecorder.setPathToDebugSymbols("path/to/linear-notes.txt");
+        freeStyleProject.getPublishersList().add(appCenterRecorder);
+
+        final HtmlForm htmlForm = jenkinsRule.createWebClient().getPage(freeStyleProject, "configure").getFormByName("config");
+        jenkinsRule.submit(htmlForm);
+
+        // When
+        final AppCenterRecorder configuredAppCenterRecorder = freeStyleProject.getPublishersList().get(AppCenterRecorder.class);
+
+        // Then
+        jenkinsRule.assertEqualDataBoundBeans(appCenterRecorder, configuredAppCenterRecorder);
+    }
 }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTaskTest.java
@@ -83,7 +83,7 @@ public class CommitUploadResourceTaskTest {
         // Then
         final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
         assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Committing resource unsuccessful: ");
+        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Committing app resource unsuccessful: ");
         assertThat(exception).hasCauseThat().hasCauseThat().isInstanceOf(HttpException.class);
         assertThat(exception).hasCauseThat().hasCauseThat().hasMessageThat().isEqualTo("HTTP 400 Client Error");
     }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTaskTest.java
@@ -5,6 +5,8 @@ import hudson.model.TaskListener;
 import hudson.util.Secret;
 import io.jenkins.plugins.appcenter.AppCenterException;
 import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolType;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -66,6 +68,49 @@ public class CommitUploadResourceTaskTest {
 
         // When
         final UploadRequest actual = task.execute(baseRequest).get();
+
+        // Then
+        assertThat(actual)
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_ReturnResponse_When_DebugSymbolsAreFound() throws Exception {
+        // Given
+        final UploadRequest request = baseRequest.newBuilder()
+            .setPathToDebugSymbols("path/to/mappings.txt")
+            .setSymbolUploadRequest(new SymbolUploadBeginRequest(SymbolType.AndroidProguard, null, "mappings.txt", "1", "1.0.0"))
+            .setSymbolUploadId("string")
+            .setSymbolUploadUrl("string")
+            .build();
+        final UploadRequest expected = request.newBuilder().setReleaseId(0).build();
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\n" +
+            "  \"release_id\": 0,\n" +
+            "  \"release_url\": \"string\"\n" +
+            "}"));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\n" +
+            "  \"symbol_upload_id\": \"string\",\n" +
+            "  \"app_id\": \"string\",\n" +
+            "  \"user\": {\n" +
+            "    \"email\": \"string\",\n" +
+            "    \"display_name\": \"string\"\n" +
+            "  },\n" +
+            "  \"status\": \"created\",\n" +
+            "  \"symbol_type\": \"AndroidProguard\",\n" +
+            "  \"symbols_uploaded\": [\n" +
+            "    {\n" +
+            "      \"symbol_id\": \"string\",\n" +
+            "      \"platform\": \"string\"\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"origin\": \"User\",\n" +
+            "  \"file_name\": \"string\",\n" +
+            "  \"file_size\": 0,\n" +
+            "  \"timestamp\": \"2019-11-17T12:12:06.701Z\"\n" +
+            "}"));
+
+        // When
+        final UploadRequest actual = task.execute(request).get();
 
         // Then
         assertThat(actual)

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTaskTest.java
@@ -5,6 +5,8 @@ import hudson.model.TaskListener;
 import hudson.util.Secret;
 import io.jenkins.plugins.appcenter.AppCenterException;
 import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolType;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -68,6 +70,38 @@ public class CreateUploadResourceTaskTest {
 
         // When
         final UploadRequest actual = task.execute(baseRequest).get();
+
+        // Then
+        assertThat(actual)
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_ReturnResponse_When_DebugSymbolsAreFound() throws Exception {
+        // Given
+        final UploadRequest request = baseRequest.newBuilder()
+            .setPathToDebugSymbols("path/to/mappings.txt")
+            .setSymbolUploadRequest(new SymbolUploadBeginRequest(SymbolType.AndroidProguard, null, "mappings.txt", "1", "1.0.0"))
+            .build();
+        final UploadRequest expected = request.newBuilder()
+            .setUploadId("string").setUploadUrl("string")
+            .setSymbolUploadId("string").setSymbolUploadUrl("string")
+            .build();
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201).setBody("{\n" +
+            "  \"upload_id\": \"string\",\n" +
+            "  \"upload_url\": \"string\",\n" +
+            "  \"asset_id\": \"string\",\n" +
+            "  \"asset_domain\": \"string\",\n" +
+            "  \"asset_token\": \"string\"\n" +
+            "}"));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200).setBody("{\n" +
+            "  \"symbol_upload_id\": \"string\",\n" +
+            "  \"upload_url\": \"string\",\n" +
+            "  \"expiration_date\": \"2019-11-17T12:01:43.953Z\"\n" +
+            "}"));
+
+        // When
+        final UploadRequest actual = task.execute(request).get();
 
         // Then
         assertThat(actual)

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTaskTest.java
@@ -106,7 +106,7 @@ public class CreateUploadResourceTaskTest {
         // Then
         final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
         assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Create upload resource unsuccessful: ");
+        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Create upload resource for app unsuccessful: ");
         assertThat(exception).hasCauseThat().hasCauseThat().isInstanceOf(HttpException.class);
         assertThat(exception).hasCauseThat().hasCauseThat().hasMessageThat().isEqualTo("HTTP 500 Server Error");
     }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CheckFileExistsTaskTest {
+public class PrerequisitesTaskTest {
 
     @Mock
     TaskListener mockTaskListener;
@@ -34,7 +34,7 @@ public class CheckFileExistsTaskTest {
 
     private UploadRequest baseRequest;
 
-    private CheckFileExistsTask task;
+    private PrerequisitesTask task;
 
     @Before
     public void setUp() {
@@ -42,7 +42,7 @@ public class CheckFileExistsTaskTest {
             .setPathToApp("path/to/*.apk")
             .build();
         given(mockTaskListener.getLogger()).willReturn(mockLogger);
-        task = new CheckFileExistsTask(mockTaskListener, mockFilePath);
+        task = new PrerequisitesTask(mockTaskListener, mockFilePath);
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
@@ -3,7 +3,11 @@ package io.jenkins.plugins.appcenter.task.internal;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.appcenter.AppCenterException;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolType;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import io.jenkins.plugins.appcenter.util.AndroidParser;
+import io.jenkins.plugins.appcenter.util.ParserFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
@@ -17,6 +21,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
@@ -32,6 +37,12 @@ public class PrerequisitesTaskTest {
     @Mock
     FilePath mockFilePath;
 
+    @Mock
+    ParserFactory mockParserFactory;
+
+    @Mock
+    AndroidParser mockAndroidParser;
+
     private UploadRequest baseRequest;
 
     private PrerequisitesTask task;
@@ -42,19 +53,67 @@ public class PrerequisitesTaskTest {
             .setPathToApp("path/to/*.apk")
             .build();
         given(mockTaskListener.getLogger()).willReturn(mockLogger);
-        task = new PrerequisitesTask(mockTaskListener, mockFilePath);
+        task = new PrerequisitesTask(mockTaskListener, mockFilePath, mockParserFactory);
     }
 
     @Test
-    public void should_ReturnTrue_When_FileExists() throws Exception {
+    public void should_ReturnModifiedRequest_When_FileExists() throws Exception {
         // Given
-        final String pathToApp = String.join(File.separator, "path", "to", "app");
+        final String pathToApp = String.join(File.separator, "path", "to", "app.apk");
         final FilePath[] files = {new FilePath(new File(pathToApp))};
         given(mockFilePath.list(anyString())).willReturn(files);
         final UploadRequest expected = baseRequest.newBuilder().setPathToApp(pathToApp).build();
 
         // When
         final UploadRequest result = task.execute(baseRequest).get();
+
+        // Then
+        assertThat(result)
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_ReturnModifiedRequest_When_DebugSymbolsExists_Android() throws Exception {
+        // Given
+        final UploadRequest request = baseRequest.newBuilder().setPathToDebugSymbols("path/to/*.txt").build();
+        final String pathToApp = String.join(File.separator, "path", "to", "app.apk");
+        final String pathToDebugSymbols = String.join(File.separator, "path", "to", "mapping.txt");
+        final FilePath[] files = {new FilePath(new File(pathToApp))};
+        final FilePath[] debugSymbols = {new FilePath(new File(pathToDebugSymbols))};
+        given(mockFilePath.list(anyString())).willReturn(files, debugSymbols);
+        given(mockFilePath.child(anyString())).willReturn(mockFilePath);
+        given(mockFilePath.getRemote()).willReturn(pathToDebugSymbols);
+        given(mockParserFactory.androidParser(any(File.class))).willReturn(mockAndroidParser);
+        given(mockAndroidParser.fileName()).willReturn("app.apk");
+        given(mockAndroidParser.versionCode()).willReturn("1");
+        given(mockAndroidParser.versionName()).willReturn("1.0.0");
+        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(SymbolType.AndroidProguard, null, "app.apk", "1", "1.0.0");
+        final UploadRequest expected = baseRequest.newBuilder().setPathToApp(pathToApp).setPathToDebugSymbols(pathToDebugSymbols).setSymbolUploadRequest(symbolUploadBeginRequest).build();
+
+        // When
+        final UploadRequest result = task.execute(request).get();
+
+        // Then
+        assertThat(result)
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_ReturnModifiedRequest_When_DebugSymbolsExists_IOS() throws Exception {
+        // Given
+        final UploadRequest request = baseRequest.newBuilder().setPathToDebugSymbols("path/to/*.zip").build();
+        final String pathToApp = String.join(File.separator, "path", "to", "app.ipa");
+        final String pathToDebugSymbols = String.join(File.separator, "path", "to", "symbols.zip");
+        final FilePath[] files = {new FilePath(new File(pathToApp))};
+        final FilePath[] debugSymbols = {new FilePath(new File(pathToDebugSymbols))};
+        given(mockFilePath.list(anyString())).willReturn(files, debugSymbols);
+        given(mockFilePath.child(anyString())).willReturn(mockFilePath);
+        given(mockFilePath.getRemote()).willReturn(pathToApp);
+        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(SymbolType.Apple, null, "app.ipa", "", "");
+        final UploadRequest expected = baseRequest.newBuilder().setPathToApp(pathToApp).setPathToDebugSymbols(pathToDebugSymbols).setSymbolUploadRequest(symbolUploadBeginRequest).build();
+
+        // When
+        final UploadRequest result = task.execute(request).get();
 
         // Then
         assertThat(result)

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTaskTest.java
@@ -77,6 +77,26 @@ public class UploadAppToResourceTaskTest {
     }
 
     @Test
+    public void should_ReturnDebugSymbolUploadId_When_DebugSymbolsAreFound() throws Exception {
+        // Given
+        final UploadRequest request = baseRequest.newBuilder()
+            .setPathToDebugSymbols("string")
+            .setSymbolUploadUrl(mockWebServer.url("upload-debug-symbols").toString())
+            .setSymbolUploadId("string")
+            .build();
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+
+        // When
+        final UploadRequest result = task.execute(request).get();
+
+        // Then
+        assertThat(result)
+            .isEqualTo(request);
+    }
+
+    @Test
     public void should_ReturnException_When_RequestIsUnSuccessful() {
         // Given
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));

--- a/src/test/java/io/jenkins/plugins/appcenter/validator/PathToDebugSymbolsValidatorTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/validator/PathToDebugSymbolsValidatorTest.java
@@ -1,0 +1,88 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class PathToDebugSymbolsValidatorTest {
+
+    private PathToDebugSymbolsValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new PathToDebugSymbolsValidator();
+    }
+
+    @Test
+    public void should_ReturnFalse_When_PathIsAbsolute_Windows() {
+        // Given
+        final String value = "C:\\\\windows\\path\\to\\symbols.zip";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void should_ReturnFalse_When_PathIsAbsolute_UnixLike() {
+        // Given
+        final String value = "/unix-like/path/to/mappings.txt";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_PathIsRelative_Windows() {
+        // Given
+        final String value = "path\\to\\symbols.zip";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_PathIsRelative_UnixLike() {
+        // Given
+        final String value = "path/to/mappings.txt";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_PathContainsEnvVars() {
+        // Given
+        final String value = "path/to/mapping-${BUILD_NUMBER}.txt";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnWarning_When_PathStartsWithEnvVars() {
+        // Given
+        final String value = "${SOME_ENV_VAR}.apk";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION
Builds upon the good work from #30 by @Kilomoana83 . Supports symbol upload functionality. This is an alternative implementation based on the PR comments I left in the pull request. We will only merge one of them.

The main difference here is that this PR aims to support both IOS and Android symbol files and uses a different architecture of the plugin that is more in line with what existed.