### PR TITLE
[JENKINS-59694] When build step fails or get aborted upload is still tried

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -129,6 +129,12 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener taskListener) throws InterruptedException, IOException {
+        final Result buildResult = run.getResult();
+        if (buildResult != null && buildResult.isWorseOrEqualTo(FAILURE)) {
+            taskListener.getLogger().println(Messages.AppCenterRecorder_DescriptorImpl_errors_upstreamBuildFailure());
+            return;
+        }
+
         if (uploadToAppCenter(run, filePath, taskListener)) {
             run.setResult(SUCCESS);
         } else {

--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -36,6 +36,9 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import static hudson.model.Result.FAILURE;
+import static hudson.model.Result.SUCCESS;
+
 @SuppressWarnings("unused")
 public final class AppCenterRecorder extends Recorder implements SimpleBuildStep {
 
@@ -127,9 +130,9 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener taskListener) throws InterruptedException, IOException {
         if (uploadToAppCenter(run, filePath, taskListener)) {
-            run.setResult(Result.SUCCESS);
+            run.setResult(SUCCESS);
         } else {
-            run.setResult(Result.FAILURE);
+            run.setResult(FAILURE);
         }
     }
 

--- a/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
@@ -1,4 +1,5 @@
 AppCenterRecorder.DescriptorImpl.warnings.mustNotStartWithEnvVar=Paths should not start with placeholders
+AppCenterRecorder.DescriptorImpl.errors.upstreamBuildFailure=Skipping due to upstream build failure
 AppCenterRecorder.DescriptorImpl.errors.missingApiToken=Please specify an AppCenter API Token
 AppCenterRecorder.DescriptorImpl.errors.invalidApiToken=API Token cannot contain whitespace
 AppCenterRecorder.DescriptorImpl.errors.missingOwnerName=Please specify an AppCenter Owner Name


### PR DESCRIPTION
We now exit early if we detect that the build result is worse or equal to FAILURE. This means the following will abort the execution of this plugin: FAILURE, NOT_BUILT, ABORTED.