### PR TITLE
[JENKINS-60008] Improve error logging

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterLogger.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterLogger.java
@@ -28,7 +28,7 @@ public interface AppCenterLogger {
         requireNonNull(throwable, "throwable cannot be null.");
 
         // Error could be an HttPException or it could not be
-        if (HttpException.class.isAssignableFrom(throwable.getClass())) {
+        if (throwable instanceof HttpException) {
             try {
                 final HttpException httpException = (HttpException) throwable;
                 final Response<?> response = requireNonNull(httpException.response(), "response cannot be null.");

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTask.java
@@ -58,7 +58,7 @@ public final class CommitUploadResourceTask implements AppCenterTask<UploadReque
             .releaseUploadsComplete(request.ownerName, request.appName, uploadId, releaseUploadEndRequest)
             .whenComplete((releaseUploadBeginResponse, throwable) -> {
                 if (throwable != null) {
-                    final AppCenterException exception = logFailure("Committing app resource unsuccessful: ", throwable);
+                    final AppCenterException exception = logFailure("Committing app resource unsuccessful", throwable);
                     future.completeExceptionally(exception);
                 } else {
                     log("Committing app resource successful.");

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
@@ -56,7 +56,7 @@ public final class CreateUploadResourceTask implements AppCenterTask<UploadReque
             .releaseUploadsCreate(request.ownerName, request.appName, releaseUploadBeginRequest)
             .whenComplete((releaseUploadBeginResponse, throwable) -> {
                 if (throwable != null) {
-                    final AppCenterException exception = logFailure("Create upload resource for app unsuccessful: ", throwable);
+                    final AppCenterException exception = logFailure("Create upload resource for app unsuccessful", throwable);
                     future.completeExceptionally(exception);
                 } else {
                     log("Create upload resource for app successful.");

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
@@ -58,7 +58,7 @@ public final class DistributeResourceTask implements AppCenterTask<UploadRequest
             .releasesUpdate(request.ownerName, request.appName, releaseId, releaseDetailsUpdateRequest)
             .whenComplete((releaseUploadBeginResponse, throwable) -> {
                 if (throwable != null) {
-                    final AppCenterException exception = logFailure("Distributing resource unsuccessful: ", throwable);
+                    final AppCenterException exception = logFailure("Distributing resource unsuccessful", throwable);
                     future.completeExceptionally(exception);
                 } else {
                     log("Distributing resource successful.");

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTask.java
@@ -68,7 +68,7 @@ public final class UploadAppToResourceTask implements AppCenterTask<UploadReques
             .uploadApp(uploadUrl, body)
             .whenComplete((responseBody, throwable) -> {
                 if (throwable != null) {
-                    final AppCenterException exception = logFailure("Upload app to resource unsuccessful: ", throwable);
+                    final AppCenterException exception = logFailure("Upload app to resource unsuccessful", throwable);
                     future.completeExceptionally(exception);
                 } else {
                     log("Upload app to resource successful.");

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/CommitUploadResourceTaskTest.java
@@ -16,7 +16,6 @@ import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import retrofit2.HttpException;
 
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
@@ -127,8 +126,6 @@ public class CommitUploadResourceTaskTest {
         // Then
         final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
         assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Committing app resource unsuccessful: ");
-        assertThat(exception).hasCauseThat().hasCauseThat().isInstanceOf(HttpException.class);
-        assertThat(exception).hasCauseThat().hasCauseThat().hasMessageThat().isEqualTo("HTTP 400 Client Error");
+        assertThat(exception).hasCauseThat().hasMessageThat().contains("Committing app resource unsuccessful: HTTP 400 Client Error: ");
     }
 }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTaskTest.java
@@ -16,7 +16,6 @@ import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import retrofit2.HttpException;
 
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
@@ -139,8 +138,6 @@ public class CreateUploadResourceTaskTest {
         // Then
         final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
         assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Create upload resource for app unsuccessful: ");
-        assertThat(exception).hasCauseThat().hasCauseThat().isInstanceOf(HttpException.class);
-        assertThat(exception).hasCauseThat().hasCauseThat().hasMessageThat().isEqualTo("HTTP 500 Server Error");
+        assertThat(exception).hasCauseThat().hasMessageThat().contains("Create upload resource for app unsuccessful: HTTP 500 Server Error: ");
     }
 }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTaskTest.java
@@ -16,7 +16,6 @@ import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import retrofit2.HttpException;
 
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
@@ -138,8 +137,6 @@ public class DistributeResourceTaskTest {
         // Then
         final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
         assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Distributing resource unsuccessful: ");
-        assertThat(exception).hasCauseThat().hasCauseThat().isInstanceOf(HttpException.class);
-        assertThat(exception).hasCauseThat().hasCauseThat().hasMessageThat().isEqualTo("HTTP 500 Server Error");
+        assertThat(exception).hasMessageThat().contains("Distributing resource unsuccessful: HTTP 500 Server Error: ");
     }
 }

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTaskTest.java
@@ -17,7 +17,6 @@ import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import retrofit2.HttpException;
 
 import java.io.PrintStream;
 import java.util.concurrent.ExecutionException;
@@ -107,9 +106,7 @@ public class UploadAppToResourceTaskTest {
         // Then
         final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
         assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo("Upload app to resource unsuccessful: ");
-        assertThat(exception).hasCauseThat().hasCauseThat().isInstanceOf(HttpException.class);
-        assertThat(exception).hasCauseThat().hasCauseThat().hasMessageThat().isEqualTo("HTTP 500 Server Error");
+        assertThat(exception).hasCauseThat().hasMessageThat().contains("Upload app to resource unsuccessful: HTTP 500 Server Error: ");
     }
 
     @Test


### PR DESCRIPTION
Previously on failure we used to simply log the error HTTP error code. This turned out to not be as useful as it needed to be for some error scenarios.

With this change we attempt to echo the JSON returned from AppCenter which is usually quite helpful in the diagnosis.

Note: We don't take automatic correction yet. This simply echos.