### PR TITLE
[JENKINS-59462] Support release notes from file

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -23,6 +23,7 @@ import io.jenkins.plugins.appcenter.validator.DistributionGroupsValidator;
 import io.jenkins.plugins.appcenter.validator.PathPlaceholderValidator;
 import io.jenkins.plugins.appcenter.validator.PathToAppValidator;
 import io.jenkins.plugins.appcenter.validator.PathToDebugSymbolsValidator;
+import io.jenkins.plugins.appcenter.validator.PathToReleaseNotesValidator;
 import io.jenkins.plugins.appcenter.validator.UsernameValidator;
 import io.jenkins.plugins.appcenter.validator.Validator;
 import jenkins.model.Jenkins;
@@ -65,6 +66,9 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
     @Nullable
     private String pathToDebugSymbols;
+
+    @Nullable
+    private String pathToReleaseNotes;
 
     @Nullable
     private transient String baseUrl;
@@ -117,6 +121,11 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
         return Util.fixNull(pathToDebugSymbols);
     }
 
+    @Nonnull
+    public String getPathToReleaseNotes() {
+        return Util.fixNull(pathToReleaseNotes);
+    }
+
     @DataBoundSetter
     public void setReleaseNotes(@Nullable String releaseNotes) {
         this.releaseNotes = Util.fixEmpty(releaseNotes);
@@ -130,6 +139,11 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     @DataBoundSetter
     public void setPathToDebugSymbols(@Nullable String pathToDebugSymbols) {
         this.pathToDebugSymbols = Util.fixEmpty(pathToDebugSymbols);
+    }
+
+    @DataBoundSetter
+    public void setPathToReleaseNotes(@Nullable String pathToReleaseNotes) {
+        this.pathToReleaseNotes = Util.fixEmpty(pathToReleaseNotes);
     }
 
     /**
@@ -268,6 +282,27 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
             final Validator pathToAppValidator = new PathToDebugSymbolsValidator();
 
             if (!pathToAppValidator.isValid(value)) {
+                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidPath());
+            }
+
+            final Validator pathPlaceholderValidator = new PathPlaceholderValidator();
+
+            if (!pathPlaceholderValidator.isValid(value)) {
+                return FormValidation.warning(Messages.AppCenterRecorder_DescriptorImpl_warnings_mustNotStartWithEnvVar());
+            }
+
+            return FormValidation.ok();
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckPathToReleaseNotes(@QueryParameter String value) {
+            if (value.trim().isEmpty()) {
+                return FormValidation.ok();
+            }
+
+            final Validator pathToReleaseNotesValidator = new PathToReleaseNotesValidator();
+
+            if (!pathToReleaseNotesValidator.isValid(value)) {
                 return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidPath());
             }
 

--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -279,9 +279,9 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
                 return FormValidation.ok();
             }
 
-            final Validator pathToAppValidator = new PathToDebugSymbolsValidator();
+            final Validator pathToDebugSymbolsValidator = new PathToDebugSymbolsValidator();
 
-            if (!pathToAppValidator.isValid(value)) {
+            if (!pathToDebugSymbolsValidator.isValid(value)) {
                 return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidPath());
             }
 

--- a/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
@@ -20,6 +20,7 @@ final class UploadModule {
             .setPathToApp(envVars.expand(appCenterRecorder.getPathToApp()))
             .setDestinationGroups(envVars.expand(appCenterRecorder.getDistributionGroups()))
             .setReleaseNotes(envVars.expand(appCenterRecorder.getReleaseNotes()))
+            .setPathToReleaseNotes(envVars.expand(appCenterRecorder.getPathToReleaseNotes()))
             .setNotifyTesters(appCenterRecorder.getNotifyTesters())
             .setPathToDebugSymbols(envVars.expand(appCenterRecorder.getPathToDebugSymbols()))
             .build();

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.appcenter.task.internal;
 
+import hudson.FilePath;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.appcenter.AppCenterException;
 import io.jenkins.plugins.appcenter.AppCenterLogger;
@@ -7,10 +8,12 @@ import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
 import io.jenkins.plugins.appcenter.model.appcenter.DestinationId;
 import io.jenkins.plugins.appcenter.model.appcenter.ReleaseUpdateRequest;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -27,12 +30,16 @@ public final class DistributeResourceTask implements AppCenterTask<UploadRequest
     @Nonnull
     private final TaskListener taskListener;
     @Nonnull
+    private final FilePath filePath;
+    @Nonnull
     private final AppCenterServiceFactory factory;
 
     @Inject
     DistributeResourceTask(@Nonnull final TaskListener taskListener,
+                           @Nonnull final FilePath filePath,
                            @Nonnull final AppCenterServiceFactory factory) {
         this.taskListener = taskListener;
+        this.filePath = filePath;
         this.factory = factory;
     }
 
@@ -71,7 +78,25 @@ public final class DistributeResourceTask implements AppCenterTask<UploadRequest
 
     @Nonnull
     private String parseReleaseNotes(@Nonnull UploadRequest request) {
-        return request.releaseNotes;
+        final String releaseNotesFromFile = parseReleaseNotesFromFile(request.pathToReleaseNotes);
+        final String separator = (!request.releaseNotes.isEmpty() && !releaseNotesFromFile.isEmpty()) ? "\n\n" : "";
+        final String combinedReleaseNotes = request.releaseNotes + separator + releaseNotesFromFile;
+
+        return StringUtils.left(combinedReleaseNotes, 5000);
+    }
+
+    @Nonnull
+    private String parseReleaseNotesFromFile(@Nonnull String pathToReleaseNotes) {
+        if (pathToReleaseNotes.isEmpty()) return "";
+
+        final FilePath releaseNotesFilePath = filePath.child(pathToReleaseNotes);
+        try {
+            return releaseNotesFilePath.readToString();
+        } catch (IOException | InterruptedException e) {
+            log(String.format("Unable to read release note file due to: %1$s", e));
+            return "";
+        }
+
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/DistributeResourceTask.java
@@ -45,7 +45,7 @@ public final class DistributeResourceTask implements AppCenterTask<UploadRequest
 
         final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
 
-        final String releaseNotes = request.releaseNotes;
+        final String releaseNotes = parseReleaseNotes(request);
         final boolean mandatoryUpdate = false;
         final List<DestinationId> destinations = Stream.of(request.destinationGroups.split(","))
             .map(String::trim)
@@ -67,6 +67,11 @@ public final class DistributeResourceTask implements AppCenterTask<UploadRequest
             });
 
         return future;
+    }
+
+    @Nonnull
+    private String parseReleaseNotes(@Nonnull UploadRequest request) {
+        return request.releaseNotes;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
@@ -44,12 +44,8 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     @Nonnull
     @Override
     public CompletableFuture<UploadRequest> execute(@Nonnull UploadRequest request) {
-        if (request.pathToDebugSymbols.trim().isEmpty()) {
-            return checkFileExists(request);
-        } else {
-            return checkFileExists(request)
-                .thenCompose(this::checkSymbolsExist);
-        }
+        return checkFileExists(request)
+            .thenCompose(this::checkSymbolsExist);
     }
 
     @Nonnull
@@ -83,6 +79,11 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     @Nonnull
     private CompletableFuture<UploadRequest> checkSymbolsExist(@Nonnull UploadRequest request) {
         final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
+
+        if (request.pathToDebugSymbols.trim().isEmpty()) {
+            future.complete(request);
+            return future;
+        }
 
         try {
             final FilePath[] listOfMatchingFilePaths = filePath.list(request.pathToDebugSymbols);
@@ -142,6 +143,35 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
         final File file = new File(filePath.child(pathToApp).getRemote());
 
         return new SymbolUploadBeginRequest(Apple, null, file.getName(), "", "");
+    }
+
+    @Nonnull
+    private CompletableFuture<UploadRequest> checkReleaseNotesExist(@Nonnull UploadRequest request) {
+        final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
+
+        try {
+            final FilePath[] listOfMatchingFilePaths = filePath.list(request.pathToReleaseNotes);
+            final int numberOfMatchingFiles = listOfMatchingFilePaths.length;
+            if (numberOfMatchingFiles > 1) {
+                final AppCenterException exception = logFailure(String.format("Multiple symbols found matching pattern: %s", request.pathToDebugSymbols));
+                future.completeExceptionally(exception);
+            } else if (numberOfMatchingFiles < 1) {
+                final AppCenterException exception = logFailure(String.format("No symbols found matching pattern: %s", request.pathToDebugSymbols));
+                future.completeExceptionally(exception);
+            } else {
+                log(String.format("Symbols found matching pattern: %s", request.pathToDebugSymbols));
+                final String pathToDebugSymbols = listOfMatchingFilePaths[0].getRemote();
+                final UploadRequest uploadRequest = request.newBuilder()
+                    .setPathToDebugSymbols(pathToDebugSymbols)
+                    .setSymbolUploadRequest(symbolUploadRequest(request.pathToApp))
+                    .build();
+                future.complete(uploadRequest);
+            }
+        } catch (IOException | InterruptedException e) {
+            future.completeExceptionally(e);
+        }
+
+        return future;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
@@ -22,7 +22,7 @@ public final class UploadRequest implements Serializable {
     @Nonnull
     public final String releaseNotes;
     @Nonnull
-    private final String pathToReleaseNotes;
+    public final String pathToReleaseNotes;
     public final boolean notifyTesters;
     @Nonnull
     public final String pathToDebugSymbols;

--- a/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
@@ -21,7 +21,8 @@ public final class UploadRequest implements Serializable {
     public final String destinationGroups;
     @Nonnull
     public final String releaseNotes;
-
+    @Nonnull
+    private final String pathToReleaseNotes;
     public final boolean notifyTesters;
     @Nonnull
     public final String pathToDebugSymbols;
@@ -51,6 +52,7 @@ public final class UploadRequest implements Serializable {
             ", pathToApp='" + pathToApp + '\'' +
             ", destinationGroups='" + destinationGroups + '\'' +
             ", releaseNotes='" + releaseNotes + '\'' +
+            ", pathToReleaseNotes='" + pathToReleaseNotes + '\'' +
             ", notifyTesters=" + notifyTesters +
             ", pathToDebugSymbols='" + pathToDebugSymbols + '\'' +
             ", uploadUrl='" + uploadUrl + '\'' +
@@ -73,6 +75,7 @@ public final class UploadRequest implements Serializable {
             pathToApp.equals(that.pathToApp) &&
             destinationGroups.equals(that.destinationGroups) &&
             releaseNotes.equals(that.releaseNotes) &&
+            pathToReleaseNotes.equals(that.pathToReleaseNotes) &&
             pathToDebugSymbols.equals(that.pathToDebugSymbols) &&
             Objects.equals(uploadUrl, that.uploadUrl) &&
             Objects.equals(uploadId, that.uploadId) &&
@@ -84,7 +87,7 @@ public final class UploadRequest implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(ownerName, appName, pathToApp, destinationGroups, releaseNotes, notifyTesters, pathToDebugSymbols, uploadUrl, uploadId, releaseId, symbolUploadRequest, symbolUploadUrl, symbolUploadId);
+        return Objects.hash(ownerName, appName, pathToApp, destinationGroups, releaseNotes, pathToReleaseNotes, notifyTesters, pathToDebugSymbols, uploadUrl, uploadId, releaseId, symbolUploadRequest, symbolUploadUrl, symbolUploadId);
     }
 
     private UploadRequest(Builder builder) {
@@ -93,6 +96,7 @@ public final class UploadRequest implements Serializable {
         this.pathToApp = builder.pathToApp;
         this.destinationGroups = builder.destinationGroups;
         this.releaseNotes = builder.releaseNotes;
+        this.pathToReleaseNotes = builder.pathToReleaseNotes;
         this.notifyTesters = builder.notifyTesters;
         this.pathToDebugSymbols = builder.pathToDebugSymbols;
 
@@ -121,6 +125,8 @@ public final class UploadRequest implements Serializable {
         private String destinationGroups;
         @Nonnull
         private String releaseNotes;
+        @Nonnull
+        private String pathToReleaseNotes;
         private boolean notifyTesters;
         @Nonnull
         private String pathToDebugSymbols;
@@ -145,6 +151,7 @@ public final class UploadRequest implements Serializable {
             pathToApp = "";
             destinationGroups = "";
             releaseNotes = "";
+            pathToReleaseNotes = "";
             notifyTesters = true;
             pathToDebugSymbols = "";
         }
@@ -155,6 +162,7 @@ public final class UploadRequest implements Serializable {
             this.pathToApp = uploadRequest.pathToApp;
             this.destinationGroups = uploadRequest.destinationGroups;
             this.releaseNotes = uploadRequest.releaseNotes;
+            this.pathToReleaseNotes = uploadRequest.pathToReleaseNotes;
             this.notifyTesters = uploadRequest.notifyTesters;
             this.pathToDebugSymbols = uploadRequest.pathToDebugSymbols;
 
@@ -189,6 +197,11 @@ public final class UploadRequest implements Serializable {
 
         public Builder setReleaseNotes(@Nonnull String releaseNotes) {
             this.releaseNotes = releaseNotes;
+            return this;
+        }
+
+        public Builder setPathToReleaseNotes(@Nonnull String pathToReleaseNotes) {
+            this.pathToReleaseNotes = pathToReleaseNotes;
             return this;
         }
 

--- a/src/main/java/io/jenkins/plugins/appcenter/validator/PathToReleaseNotesValidator.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/validator/PathToReleaseNotesValidator.java
@@ -1,0 +1,15 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import hudson.Util;
+
+import javax.annotation.Nonnull;
+import java.util.function.Predicate;
+
+public final class PathToReleaseNotesValidator extends Validator {
+
+    @Nonnull
+    @Override
+    protected Predicate<String> predicate() {
+        return Util::isRelativePath;
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
@@ -39,12 +39,12 @@
     <f:section title="Release Notes">
 
         <f:entry title="${%Release Notes}" field="releaseNotes"
-                 description="${%Optional, release notes in markdown format.}">
+                 description="${%Optional, but merged with other type release notes types. Merged limit 5000 characters.}">
             <f:textarea/>
         </f:entry>
 
         <f:entry title="${%Release Notes From A File}" field="pathToReleaseNotes"
-                 description="${%Optional, release notes in markdown format.}">
+                 description="${%Optional, but merged with other type release notes types. Merged limit 5000 characters.}">
             <f:textbox/>
         </f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
@@ -26,11 +26,6 @@
         <f:textbox/>
     </f:entry>
 
-    <f:entry title="${%Release Notes}" field="releaseNotes"
-             description="${%Optional, release notes in markdown format.}">
-        <f:textarea/>
-    </f:entry>
-
     <f:entry title="${%Notify Testers}" field="notifyTesters"
              description="${%Optional, defaults to true}">
         <f:checkbox name="notifyTesters" default="true"/>
@@ -40,5 +35,19 @@
              description="${%Optional, relative path to debug symbols.}">
         <f:textbox/>
     </f:entry>
+
+    <f:section title="Release Notes">
+
+        <f:entry title="${%Release Notes}" field="releaseNotes"
+                 description="${%Optional, release notes in markdown format.}">
+            <f:textarea/>
+        </f:entry>
+
+        <f:entry title="${%Release Notes From A File}" field="pathToReleaseNotes"
+                 description="${%Optional, release notes in markdown format.}">
+            <f:textbox/>
+        </f:entry>
+
+    </f:section>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/help-pathToReleaseNotes.html
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/help-pathToReleaseNotes.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        Relative path to release notes. Supports variable substitution. Supports Markdown syntax. <strong>NOTE:</strong> Limited to 5000 characters or less.
+    </p>
+    <hr/>
+    <p>
+        For example: <code>three/days/linearnotes.md</code> or <code>three/days/${NOTES}.md</code>
+    </p>
+</div>

--- a/src/test/java/io/jenkins/plugins/appcenter/FreestyleTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/FreestyleTest.java
@@ -27,7 +27,7 @@ public class FreestyleTest {
     @Before
     public void setUp() throws IOException {
         freeStyleProject = jenkinsRule.createFreeStyleProject();
-        freeStyleProject.getBuildersList().add(TestUtil.createFileForFreeStyle("three/days/xiola.apk"));
+        freeStyleProject.getBuildersList().add(TestUtil.createFile("three/days/xiola.apk"));
 
         final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("at-this-moment-you-should-be-with-us", "janes-addiction", "ritual-de-lo-habitual", "three/days/xiola.apk", "casey, niccoli");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").toString());

--- a/src/test/java/io/jenkins/plugins/appcenter/NodeTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/NodeTest.java
@@ -34,7 +34,7 @@ public class NodeTest {
     @Before
     public void setUp() throws Exception {
         freeStyleProject = jenkinsRule.createFreeStyleProject();
-        freeStyleProject.getBuildersList().add(TestUtil.createFileForFreeStyle("three/days/xiola.apk"));
+        freeStyleProject.getBuildersList().add(TestUtil.createFile("three/days/xiola.apk"));
 
         final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("at-this-moment-you-should-be-with-us", "janes-addiction", "ritual-de-lo-habitual", "three/days/xiola.apk", "casey, niccoli");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").toString());

--- a/src/test/java/io/jenkins/plugins/appcenter/ProxyTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/ProxyTest.java
@@ -35,7 +35,7 @@ public class ProxyTest {
     @Before
     public void setUp() throws IOException {
         freeStyleProject = jenkinsRule.createFreeStyleProject();
-        freeStyleProject.getBuildersList().add(TestUtil.createFileForFreeStyle("three/days/xiola.apk"));
+        freeStyleProject.getBuildersList().add(TestUtil.createFile("three/days/xiola.apk"));
 
         final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("at-this-moment-you-should-be-with-us", "janes-addiction", "ritual-de-lo-habitual", "three/days/xiola.apk", "casey, niccoli");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").toString()); // Notice this is *not* set to the proxy address

--- a/src/test/java/io/jenkins/plugins/appcenter/util/MockWebServerUtil.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/util/MockWebServerUtil.java
@@ -42,6 +42,63 @@ public class MockWebServerUtil {
             "}"));
     }
 
+    public static void enqueueSuccessWithSymbols(final @Nonnull MockWebServer mockAppCenterServer) {
+        // Create upload resource for app
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_CREATED).setBody("{\n" +
+            "  \"upload_id\": \"string\",\n" +
+            "  \"upload_url\": \"" + mockAppCenterServer.url("/").toString() + "\",\n" +
+            "  \"asset_id\": \"string\",\n" +
+            "  \"asset_domain\": \"string\",\n" +
+            "  \"asset_token\": \"string\"\n" +
+            "}"));
+
+        // Create upload resource for debug symbols
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_CREATED).setBody("{\n" +
+            "  \"symbol_upload_id\": \"string\",\n" +
+            "  \"upload_url\": \"" + mockAppCenterServer.url("/").toString() + "\",\n" +
+            "  \"expiration_date\": \"2020-03-18T21:16:22.188Z\"\n" +
+            "}"));
+
+        // Upload app
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_OK));
+
+        // Upload debug symbols
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_OK));
+
+        // Commit app
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_OK).setBody("{\n" +
+            "  \"release_id\": 0,\n" +
+            "  \"release_url\": \"string\"\n" +
+            "}"));
+
+        // Commit debug symbols
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_OK).setBody("{\n" +
+            "  \"symbol_upload_id\": \"string\",\n" +
+            "  \"app_id\": \"string\",\n" +
+            "  \"user\": {\n" +
+            "    \"email\": \"string\",\n" +
+            "    \"display_name\": \"string\"\n" +
+            "  },\n" +
+            "  \"status\": \"created\",\n" +
+            "  \"symbol_type\": \"Apple\",\n" +
+            "  \"symbols_uploaded\": [\n" +
+            "    {\n" +
+            "      \"symbol_id\": \"string\",\n" +
+            "      \"platform\": \"string\"\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"origin\": \"User\",\n" +
+            "  \"file_name\": \"string\",\n" +
+            "  \"file_size\": 0,\n" +
+            "  \"timestamp\": \"2020-03-18T21:28:19.024Z\"\n" +
+            "}"));
+
+        // Distribute app
+        mockAppCenterServer.enqueue(new MockResponse().setResponseCode(HTTP_OK).setBody("{\n" +
+            "  \"release_notes\": \"string\"\n" +
+            "}"));
+    }
+
     public static void enqueueFailure(final @Nonnull MockWebServer mockWebServer) {
         mockWebServer.enqueue(new MockResponse().setResponseCode(HTTP_INTERNAL_ERROR));
     }

--- a/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
@@ -18,10 +18,6 @@ public final class TestUtil {
         return new TestAppWriter(pathToFile, content);
     }
 
-    public static TestBuilder createFileForPipeline(final @Nonnull String pathToFile) {
-        return new TestAppWriter(pathToFile, "all of us with wings");
-    }
-
     private static class TestAppWriter extends TestBuilder {
 
         @Nonnull

--- a/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
@@ -11,25 +11,32 @@ import java.util.Objects;
 
 public final class TestUtil {
     public static TestBuilder createFileForFreeStyle(final @Nonnull String pathToFile) {
-        return new TestAppWriter(pathToFile);
+        return new TestAppWriter(pathToFile, "all of us with wings");
+    }
+
+    public static TestBuilder createFileForFreeStyle(final @Nonnull String pathToFile, final @Nonnull String content) {
+        return new TestAppWriter(pathToFile, content);
     }
 
     public static TestBuilder createFileForPipeline(final @Nonnull String pathToFile) {
-        return new TestAppWriter(pathToFile);
+        return new TestAppWriter(pathToFile, "all of us with wings");
     }
 
     private static class TestAppWriter extends TestBuilder {
 
         @Nonnull
         private final String pathToFile;
+        @Nonnull
+        private final String content;
 
-        private TestAppWriter(final @Nonnull String pathToFile) {
+        private TestAppWriter(final @Nonnull String pathToFile, final @Nonnull String content) {
             this.pathToFile = pathToFile;
+            this.content = content;
         }
 
         public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException, IOException {
-            Objects.requireNonNull(build.getWorkspace()).child(pathToFile).write("all of us with wings", "UTF-8");
+            Objects.requireNonNull(build.getWorkspace()).child(pathToFile).write(content, "UTF-8");
             return true;
         }
     }

--- a/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 public final class TestUtil {
     public static TestBuilder createFileForFreeStyle(final @Nonnull String pathToFile) {
-        return new TestAppWriter(pathToFile, "all of us with wings");
+        return createFileForFreeStyle(pathToFile, "all of us with wings");
     }
 
     public static TestBuilder createFileForFreeStyle(final @Nonnull String pathToFile, final @Nonnull String content) {

--- a/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/util/TestUtil.java
@@ -10,11 +10,11 @@ import java.io.IOException;
 import java.util.Objects;
 
 public final class TestUtil {
-    public static TestBuilder createFileForFreeStyle(final @Nonnull String pathToFile) {
-        return createFileForFreeStyle(pathToFile, "all of us with wings");
+    public static TestBuilder createFile(final @Nonnull String pathToFile) {
+        return createFile(pathToFile, "all of us with wings");
     }
 
-    public static TestBuilder createFileForFreeStyle(final @Nonnull String pathToFile, final @Nonnull String content) {
+    public static TestBuilder createFile(final @Nonnull String pathToFile, final @Nonnull String content) {
         return new TestAppWriter(pathToFile, content);
     }
 

--- a/src/test/java/io/jenkins/plugins/appcenter/validator/PathToReleaseNotesValidatorTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/validator/PathToReleaseNotesValidatorTest.java
@@ -1,0 +1,88 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class PathToReleaseNotesValidatorTest {
+
+    private PathToReleaseNotesValidator validator;
+
+    @Before
+    public void setUp() {
+        validator = new PathToReleaseNotesValidator();
+    }
+
+    @Test
+    public void should_ReturnFalse_When_PathIsAbsolute_Windows() {
+        // Given
+        final String value = "C:\\\\windows\\path\\to\\release-notes.md";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void should_ReturnFalse_When_PathIsAbsolute_UnixLike() {
+        // Given
+        final String value = "/unix-like/path/to/release-notes.md";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_PathIsRelative_Windows() {
+        // Given
+        final String value = "path\\to\\release-notes.md";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_PathIsRelative_UnixLike() {
+        // Given
+        final String value = "path/to/release-notes.md";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_PathContainsEnvVars() {
+        // Given
+        final String value = "path/to/release-notes-${BUILD_NUMBER}.md";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnWarning_When_PathStartsWithEnvVars() {
+        // Given
+        final String value = "${SOME_ENV_VAR}.apk";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION
Adds support for release note via files.

Combines any manual release notes with those from a file. Limits to 5000 characters (AppCenter restriction).