### PR TITLE
[JENKINS-61700] Windows upload needs required build_version parameter

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -19,6 +19,7 @@ import io.jenkins.plugins.appcenter.di.DaggerAppCenterComponent;
 import io.jenkins.plugins.appcenter.task.UploadTask;
 import io.jenkins.plugins.appcenter.validator.ApiTokenValidator;
 import io.jenkins.plugins.appcenter.validator.AppNameValidator;
+import io.jenkins.plugins.appcenter.validator.BuildVersionValidator;
 import io.jenkins.plugins.appcenter.validator.DistributionGroupsValidator;
 import io.jenkins.plugins.appcenter.validator.PathPlaceholderValidator;
 import io.jenkins.plugins.appcenter.validator.PathToAppValidator;
@@ -63,6 +64,9 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     private String releaseNotes;
 
     private boolean notifyTesters = true;
+
+    @Nullable
+    private String buildVersion;
 
     @Nullable
     private String pathToDebugSymbols;
@@ -114,6 +118,11 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
     public boolean getNotifyTesters() {
         return notifyTesters;
+    }
+
+    @Nonnull
+    public String getBuildVersion() {
+        return Util.fixNull(buildVersion);
     }
 
     @Nonnull
@@ -268,6 +277,21 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
 
             if (!validator.isValid(value)) {
                 return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidDistributionGroups());
+            }
+
+            return FormValidation.ok();
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckBuildVersion(@QueryParameter String value) {
+            if (value.trim().isEmpty()) {
+                return FormValidation.ok();
+            }
+
+            final Validator buildVersionValidator = new BuildVersionValidator();
+
+            if (!buildVersionValidator.isValid(value)) {
+                return FormValidation.error(Messages.AppCenterRecorder_DescriptorImpl_errors_invalidBuildVersion());
             }
 
             return FormValidation.ok();

--- a/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/AppCenterRecorder.java
@@ -146,6 +146,11 @@ public final class AppCenterRecorder extends Recorder implements SimpleBuildStep
     }
 
     @DataBoundSetter
+    public void setBuildVersion(@Nullable String buildVersion) {
+        this.buildVersion = Util.fixEmpty(buildVersion);
+    }
+
+    @DataBoundSetter
     public void setPathToDebugSymbols(@Nullable String pathToDebugSymbols) {
         this.pathToDebugSymbols = Util.fixEmpty(pathToDebugSymbols);
     }

--- a/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/di/UploadModule.java
@@ -22,6 +22,7 @@ final class UploadModule {
             .setReleaseNotes(envVars.expand(appCenterRecorder.getReleaseNotes()))
             .setPathToReleaseNotes(envVars.expand(appCenterRecorder.getPathToReleaseNotes()))
             .setNotifyTesters(appCenterRecorder.getNotifyTesters())
+            .setBuildVersion(envVars.expand(appCenterRecorder.getBuildVersion()))
             .setPathToDebugSymbols(envVars.expand(appCenterRecorder.getPathToDebugSymbols()))
             .build();
     }

--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/CreateUploadResourceTask.java
@@ -51,7 +51,7 @@ public final class CreateUploadResourceTask implements AppCenterTask<UploadReque
         final CompletableFuture<UploadRequest> future = new CompletableFuture<>();
 
         // TODO: Pass in the release_id as an optional parameter from the UI. Don't use it if  not available
-        final ReleaseUploadBeginRequest releaseUploadBeginRequest = new ReleaseUploadBeginRequest(null, null, null);
+        final ReleaseUploadBeginRequest releaseUploadBeginRequest = new ReleaseUploadBeginRequest(null, request.buildVersion, null);
         factory.createAppCenterService()
             .releaseUploadsCreate(request.ownerName, request.appName, releaseUploadBeginRequest)
             .whenComplete((releaseUploadBeginResponse, throwable) -> {

--- a/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/request/UploadRequest.java
@@ -25,6 +25,8 @@ public final class UploadRequest implements Serializable {
     public final String pathToReleaseNotes;
     public final boolean notifyTesters;
     @Nonnull
+    public final String buildVersion;
+    @Nonnull
     public final String pathToDebugSymbols;
 
     // Properties above this line are expected to be set by plugin configuration before a run they should be nonnull.
@@ -54,6 +56,7 @@ public final class UploadRequest implements Serializable {
             ", releaseNotes='" + releaseNotes + '\'' +
             ", pathToReleaseNotes='" + pathToReleaseNotes + '\'' +
             ", notifyTesters=" + notifyTesters +
+            ", buildVersion='" + buildVersion + '\'' +
             ", pathToDebugSymbols='" + pathToDebugSymbols + '\'' +
             ", uploadUrl='" + uploadUrl + '\'' +
             ", uploadId='" + uploadId + '\'' +
@@ -76,6 +79,7 @@ public final class UploadRequest implements Serializable {
             destinationGroups.equals(that.destinationGroups) &&
             releaseNotes.equals(that.releaseNotes) &&
             pathToReleaseNotes.equals(that.pathToReleaseNotes) &&
+            buildVersion.equals(that.buildVersion) &&
             pathToDebugSymbols.equals(that.pathToDebugSymbols) &&
             Objects.equals(uploadUrl, that.uploadUrl) &&
             Objects.equals(uploadId, that.uploadId) &&
@@ -87,7 +91,7 @@ public final class UploadRequest implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(ownerName, appName, pathToApp, destinationGroups, releaseNotes, pathToReleaseNotes, notifyTesters, pathToDebugSymbols, uploadUrl, uploadId, releaseId, symbolUploadRequest, symbolUploadUrl, symbolUploadId);
+        return Objects.hash(ownerName, appName, pathToApp, destinationGroups, releaseNotes, pathToReleaseNotes, notifyTesters, buildVersion, pathToDebugSymbols, uploadUrl, uploadId, releaseId, symbolUploadRequest, symbolUploadUrl, symbolUploadId);
     }
 
     private UploadRequest(Builder builder) {
@@ -98,6 +102,7 @@ public final class UploadRequest implements Serializable {
         this.releaseNotes = builder.releaseNotes;
         this.pathToReleaseNotes = builder.pathToReleaseNotes;
         this.notifyTesters = builder.notifyTesters;
+        this.buildVersion = builder.buildVersion;
         this.pathToDebugSymbols = builder.pathToDebugSymbols;
 
         // Expected to be nullable until they are added during UploadTask.
@@ -129,6 +134,8 @@ public final class UploadRequest implements Serializable {
         private String pathToReleaseNotes;
         private boolean notifyTesters;
         @Nonnull
+        private String buildVersion;
+        @Nonnull
         private String pathToDebugSymbols;
 
         // Expected to be nullable until they are added during UploadTask.
@@ -153,6 +160,7 @@ public final class UploadRequest implements Serializable {
             releaseNotes = "";
             pathToReleaseNotes = "";
             notifyTesters = true;
+            buildVersion = "";
             pathToDebugSymbols = "";
         }
 
@@ -164,6 +172,7 @@ public final class UploadRequest implements Serializable {
             this.releaseNotes = uploadRequest.releaseNotes;
             this.pathToReleaseNotes = uploadRequest.pathToReleaseNotes;
             this.notifyTesters = uploadRequest.notifyTesters;
+            this.buildVersion = uploadRequest.buildVersion;
             this.pathToDebugSymbols = uploadRequest.pathToDebugSymbols;
 
             // Expected to be nullable until they are added during UploadTask.
@@ -207,6 +216,11 @@ public final class UploadRequest implements Serializable {
 
         public Builder setNotifyTesters(boolean notifyTesters) {
             this.notifyTesters = notifyTesters;
+            return this;
+        }
+
+        public Builder setBuildVersion(@Nonnull String buildVersion) {
+            this.buildVersion = buildVersion;
             return this;
         }
 

--- a/src/main/java/io/jenkins/plugins/appcenter/validator/BuildVersionValidator.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/validator/BuildVersionValidator.java
@@ -1,0 +1,15 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+
+public final class BuildVersionValidator extends Validator {
+
+    @Nonnull
+    @Override
+    protected Predicate<String> predicate() {
+        return value -> !value.contains(" ");
+    }
+
+}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Upload new versions of your Android, iOS, Windows and MacOS applications to AppCenter.
+    Upload new versions of your Android, iOS, MacOS, and (limited) Windows applications to AppCenter.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Upload new versions of your Android, iOS, and MacOS applications to AppCenter.
+    Upload new versions of your Android, iOS, Windows and MacOS applications to AppCenter.
 </div>

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/config.jelly
@@ -31,6 +31,11 @@
         <f:checkbox name="notifyTesters" default="true"/>
     </f:entry>
 
+    <f:entry title="${%Build version}" field="buildVersion"
+                 description="${%Optional, version string for the build.}">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%Path To Debug Symbols}" field="pathToDebugSymbols"
              description="${%Optional, relative path to debug symbols.}">
         <f:textbox/>

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/help-buildVersion.html
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/help-buildVersion.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        <strong>NOTE:</strong> Build version might be not optional on certain platform releases. Supports variable substitution.
+    </p>
+    <hr/>
+    <p>
+        For example: <code>1.2.0</code> or <code>${version}</code>
+    </p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/help-buildVersion.html
+++ b/src/main/resources/io/jenkins/plugins/appcenter/AppCenterRecorder/help-buildVersion.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        <strong>NOTE:</strong> Build version might be not optional on certain platform releases. Supports variable substitution.
+        <strong>NOTE:</strong> Build version might be mandatory on certain platform releases. Supports variable substitution.
     </p>
     <hr/>
     <p>

--- a/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
@@ -10,4 +10,5 @@ AppCenterRecorder.DescriptorImpl.errors.missingDistributionGroups=Please specify
 AppCenterRecorder.DescriptorImpl.errors.invalidDistributionGroups=Distribution Groups cannot be empty
 AppCenterRecorder.DescriptorImpl.errors.missingPathToApp=Please specify a path to the app you wish to upload
 AppCenterRecorder.DescriptorImpl.errors.invalidPath=Invalid path
+AppCenterRecorder.DescriptorImpl.errors.invalidBuildVersion=Build version cannot contain whitespace
 AppCenterRecorder.DescriptorImpl.DisplayName=Upload app to AppCenter

--- a/src/test/java/io/jenkins/plugins/appcenter/EnvInterpolationTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/EnvInterpolationTest.java
@@ -41,6 +41,7 @@ public class EnvInterpolationTest {
         envVars.put("OWNER_NAME", "janes-addiction");
         envVars.put("APP_NAME", "ritual-de-lo-habitual");
         envVars.put("PATH_TO_APP", "three/days/xiola.ipa");
+        envVars.put("BUILD_VERSION", "1.2.3");
         envVars.put("PATH_TO_DEBUG_SYMBOLS", "three/days/blue.zip");
         envVars.put("DISTRIBUTION_GROUPS", "casey, niccoli");
         envVars.put("RELEASE_NOTES", "I miss you my dear Xiola");
@@ -55,6 +56,7 @@ public class EnvInterpolationTest {
             "${PATH_TO_APP}",
             "${DISTRIBUTION_GROUPS}"
         );
+        appCenterRecorder.setBuildVersion("${BUILD_VERSION}");
         appCenterRecorder.setPathToDebugSymbols("${PATH_TO_DEBUG_SYMBOLS}");
         appCenterRecorder.setReleaseNotes("${RELEASE_NOTES}");
         appCenterRecorder.setPathToReleaseNotes("${PATH_TO_RELEASE_NOTES}");


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-61700

I was able to upload Windows builds with this. Variable substitution works too. I will look into adding some additional tests but would be also happy if someone can help me with them.