### PR TITLE
[JENKINS-63912] Add release drafter GitHub action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ indent_style = space
 indent_size = 4
 max_line_length = 180
 
-[*.json]
+[*.{json,yml}]
 indent_size = 2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # config-name: my-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Seems like the old Github app was a bit broken. Nowadays all the cool kids are using the Github Action. We should too.