### PR TITLE
[JENKINS-64188] Replace Netty with OkHttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,24 +39,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-storage-blob</artifactId>
-            <version>12.8.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.azure</groupId>
-                    <artifactId>azure-core-http-netty</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.azure</groupId>
-            <artifactId>azure-core-http-okhttp</artifactId>
-            <version>1.2.5</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.dagger</groupId>
             <artifactId>dagger</artifactId>
             <version>2.29.1</version>
@@ -97,6 +79,24 @@
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi</artifactId>
             <version>1.8.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <version>12.8.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-okhttp</artifactId>
+            <version>1.2.5</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.7</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
@@ -41,6 +42,24 @@
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
             <version>12.8.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.azure</groupId>
+                    <artifactId>azure-core-http-netty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-okhttp</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>1.4.10</version>
         </dependency>
 
         <dependency>
@@ -71,13 +90,13 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.14.3</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>3.14.3</version>
+            <version>4.9.0</version>
         </dependency>
 
         <dependency>
@@ -170,7 +189,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>3.14.3</version>
+            <version>4.9.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -257,5 +276,31 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>1.4.10</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <source>src/main/java</source>
+                                <source>target/generated-sources/localizer</source>
+                                <source>target/generated-sources/annotations</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>1.4.10</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.dagger</groupId>
             <artifactId>dagger</artifactId>
             <version>2.29.1</version>
@@ -73,18 +67,6 @@
             <artifactId>dagger-compiler</artifactId>
             <version>2.29.1</version>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
         </dependency>
 
         <dependency>
@@ -211,7 +193,6 @@
 
     <dependencyManagement>
         <dependencies>
-
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.222.x</artifactId>
@@ -242,6 +223,30 @@
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
                 <version>3.3.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>1.4.10</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>1.4.10</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>27.0.1-jre</version>
             </dependency>
 
         </dependencies>
@@ -276,31 +281,5 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.4.10</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <source>src/main/java</source>
-                                <source>target/generated-sources/localizer</source>
-                                <source>target/generated-sources/annotations</source>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.222.x</artifactId>
-                <version>10</version>
+                <version>17</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.7</version>
+        <version>4.13</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,17 @@
     <properties>
         <jenkins.version>2.222.3</jenkins.version>
         <java.level>8</java.level>
+        <dagger.version>2.29.1</dagger.version>
+        <okhttp.version>4.9.0</okhttp.version>
+        <retrofit.version>2.6.2</retrofit.version>
+        <moshi.version>1.8.0</moshi.version>
+        <azure-storage-blob.version>12.8.0</azure-storage-blob.version>
+        <azure-core-http-okhttp.version>1.2.5</azure-core-http-okhttp.version>
+        <apk-parser.version>2.6.9</apk-parser.version>
+        <mock-slave.version>1.13</mock-slave.version>
+        <truth.version>1.0</truth.version>
+        <junit.version>4.13.1</junit.version>
+        <mockito.version>3.0.0</mockito.version>
     </properties>
 
     <groupId>io.jenkins.plugins</groupId>
@@ -41,50 +52,50 @@
         <dependency>
             <groupId>com.google.dagger</groupId>
             <artifactId>dagger</artifactId>
-            <version>2.29.1</version>
+            <version>${dagger.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.dagger</groupId>
             <artifactId>dagger-compiler</artifactId>
-            <version>2.29.1</version>
+            <version>${dagger.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.0</version>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
-            <version>4.9.0</version>
+            <version>${okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.6.2</version>
+            <version>${retrofit.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-moshi</artifactId>
-            <version>2.6.2</version>
+            <version>${retrofit.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi</artifactId>
-            <version>1.8.0</version>
+            <version>${moshi.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.8.0</version>
+            <version>${azure-storage-blob.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.azure</groupId>
@@ -96,13 +107,13 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-http-okhttp</artifactId>
-            <version>1.2.5</version>
+            <version>${azure-core-http-okhttp.version}</version>
         </dependency>
 
         <dependency>
             <groupId>net.dongliu</groupId>
             <artifactId>apk-parser</artifactId>
-            <version>2.6.9</version>
+            <version>${apk-parser.version}</version>
         </dependency>
 
         <dependency>
@@ -150,42 +161,42 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mock-slave</artifactId>
-            <version>1.13</version>
+            <version>${mock-slave.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>1.0</version>
+            <version>${truth.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.truth.extensions</groupId>
             <artifactId>truth-java8-extension</artifactId>
-            <version>1.0</version>
+            <version>${truth.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
-            <version>4.9.0</version>
+            <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.0.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/api/AppCenterServiceFactory.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.appcenter.api;
 
-import com.azure.core.http.ProxyOptions;
-import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobClientBuilder;
 import com.google.common.net.HttpHeaders;
@@ -18,11 +17,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.concurrent.TimeUnit;
 
-import static com.azure.core.http.ProxyOptions.Type.HTTP;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 @Singleton
@@ -90,53 +87,23 @@ public final class AppCenterServiceFactory implements Serializable {
     }
 
     public BlobClient createBlobUploadService(@Nonnull final String uploadUrl) {
-        //Workaround for bug in Azure Blob Storage, as AppCenter returns the upload URL with a port attached
-        //See https://github.com/Azure/azure-sdk-for-java/issues/15827
         final HttpUrl httpUploadUrl = HttpUrl.get(uploadUrl);
-        final String file;
-        if (httpUploadUrl.encodedQuery() != null) {
-            file = httpUploadUrl.encodedPath() + "?" + httpUploadUrl.encodedQuery();
-        } else {
-            file = httpUploadUrl.encodedPath();
-        }
-
-        final String uploadUrlWithoutPort = String.format("%1$s://%2$s%3$s", httpUploadUrl.scheme(), httpUploadUrl.host(), file);
-
-        // For the future it would be nice to simply configure this with the azure-core-http-okhttp artefact so that we can make use of the shared OkHttp configuration for
-        // timeouts and proxy settings. For the time being configure this manually. https://github.com/Azure/azure-sdk-for-java/wiki/HTTP-clients
-
-
-        final NettyAsyncHttpClientBuilder nettyAsyncHttpClientBuilder = new NettyAsyncHttpClientBuilder();
-
-        if (proxyConfiguration != null) {
-            // Note in the future we will configure an OkHttp client instead of a NettyHttp client. For the time being the function name setProxy does not make a lot of sense for
-            // Netty use. We are merely using it to get a configuration from Jenkins in order t set Netty ProxyOptions if needed.
-            final Proxy proxy = setProxy(proxyConfiguration, httpUploadUrl.host());
-            final ProxyOptions proxyOptions;
-            if (proxy != Proxy.NO_PROXY) {
-                // If this destination should go via a proxy configure it here.
-                proxyOptions = new ProxyOptions(HTTP, new InetSocketAddress(httpUploadUrl.host(), httpUploadUrl.port()));
-            } else {
-                // Otherwise it should go direct.
-                proxyOptions = null;
-            }
-
-            final String username = proxyConfiguration.getUserName();
-            final String password = proxyConfiguration.getPassword();
-
-            if (proxyOptions != null && isNotBlank(username) && isNotBlank(password)) {
-                // Additionally if we have a valid username:password set in Jenkins Global configuration for proxies then make use of it.
-                proxyOptions.setCredentials(username, password);
-            }
-
-            nettyAsyncHttpClientBuilder
-                .proxy(proxyOptions);
-        }
+        final OkHttpAsyncHttpClientBuilder okHttpAsyncHttpClientBuilder = new OkHttpAsyncHttpClientBuilder(createHttpClientBuilder(httpUploadUrl).build());
 
         return new BlobClientBuilder()
-            .endpoint(uploadUrlWithoutPort)
-            .httpClient(nettyAsyncHttpClientBuilder.build())
+            .endpoint(workaroundAzureSdkForJava15827(httpUploadUrl))
+            .httpClient(okHttpAsyncHttpClientBuilder.build())
             .buildClient();
+    }
+
+    @Nonnull
+    private String workaroundAzureSdkForJava15827(@Nonnull HttpUrl httpUploadUrl) {
+        // Workaround for bug in Azure Blob Storage, as AppCenter returns the upload URL with a port attached.
+        // See https://github.com/Azure/azure-sdk-for-java/issues/15827
+
+        // toString() will remove the well known HTTPS of 443 or keep it if there is a custom port. Hence this results in stripping the port if needed (e.g. if we are trying to
+        // connect to https://<accountname>.blob.core.windows.net:443) or keeps it (e.g. if we are trying to connect to test servers https://127.0.0.1:1234)
+        return httpUploadUrl.toString();
     }
 
     private OkHttpClient.Builder createHttpClientBuilder(@Nonnull final HttpUrl httpUrl) {

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/UploadAppToResourceTaskTest.java
@@ -8,11 +8,11 @@ import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
 import io.jenkins.plugins.appcenter.task.request.UploadRequest;
 import io.jenkins.plugins.appcenter.util.RemoteFileUtils;
 import io.jenkins.plugins.appcenter.util.TestFileUtil;
+import okhttp3.Headers;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
@@ -97,17 +97,25 @@ public class UploadAppToResourceTaskTest {
     }
 
     @Test
-    @Ignore("Unable to test chunked uploads due to inability to mock BlobStorage server using MockWebserver.")
     public void should_ReturnDebugSymbolUploadId_When_DebugSymbolsAreFound_ChunkedMode() throws Exception {
         // Given
         final UploadRequest request = baseRequest.newBuilder()
             .setPathToDebugSymbols("string")
-            .setSymbolUploadUrl("<accountname>.blob.core.windows.net/upload-debug-symbols")
+            .setSymbolUploadUrl(mockWebServer.url("perry/casey/xiola").toString())
             .setSymbolUploadId("string")
             .build();
 
         mockWebServer.enqueue(new MockResponse().setResponseCode(200));
-        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+        mockWebServer.enqueue(new MockResponse().setResponseCode(201)
+            .setHeaders(Headers.of(
+                "ETag", "0x8CB171BA9E94B0B",
+                "Last-Modified", "Thu, 01 Jan 1970 00:00:00 GMT",
+                "Content-MD5", "sQqNsWTgdUEFt6mb5y4/5Q==",
+                "x-ms-request-server-encrypted", "false",
+                "x-ms-version-id", "Thu, 01 Jan 1970 00:00:00 GMT"
+            ))
+            .setChunkedBody("", 1)
+        );
 
         given(mockRemoteFileUtils.getRemoteFile(anyString())).willReturn(TestFileUtil.createFileForTesting(), TestFileUtil.createLargeFileForTesting());
 


### PR DESCRIPTION
Mostly an internal plumbing job. Remove the Netty Http engine and favour OkHttp. It rocks! 

Also re-enable the ignored test for large file uploads.