### PR TITLE
[JENKINS-64259] Add Kotlin as a main dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <version>4.13</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
         <jenkins.version>2.222.3</jenkins.version>
         <java.level>8</java.level>
+        <kotlin.version>1.4.10</kotlin.version>
         <dagger.version>2.29.1</dagger.version>
         <okhttp.version>4.9.0</okhttp.version>
         <retrofit.version>2.6.2</retrofit.version>
@@ -46,6 +48,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
         </dependency>
 
         <dependency>
@@ -239,18 +247,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.30</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>1.4.10</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
-                <version>1.4.10</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Promote Kotlin into the main dependency section. I _should_ have been pulled in with one of the other dependencies but clearly it hasn't or some weird classpath loading is happening. 

**Note**: This may not work :(