### PR TITLE
JENKINS-65285 The iOS symbol upload was uploading a copy of the app, not the symbols file.

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTask.java
@@ -114,7 +114,7 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     @Nonnull
     private SymbolUploadBeginRequest symbolUploadRequest(@Nonnull String pathToApp, @Nonnull String pathToDebugSymbols) throws IllegalStateException, IOException {
         if (pathToApp.endsWith(".apk")) return androidSymbolsUpload(pathToApp, pathToDebugSymbols);
-        if (pathToApp.endsWith(".ipa") || pathToApp.endsWith(".app.zip") || pathToApp.endsWith(".pkg") || pathToApp.endsWith(".dmg")) return appleSymbolsUpload(pathToApp);
+        if (pathToApp.endsWith(".ipa") || pathToApp.endsWith(".app.zip") || pathToApp.endsWith(".pkg") || pathToApp.endsWith(".dmg")) return appleSymbolsUpload(pathToDebugSymbols);
 
         throw new IllegalStateException("Unable to determine application type and therefore debug symbol type");
     }
@@ -141,8 +141,8 @@ public final class PrerequisitesTask implements AppCenterTask<UploadRequest>, Ap
     }
 
     @Nonnull
-    private SymbolUploadBeginRequest appleSymbolsUpload(@Nonnull String pathToApp) {
-        final File file = new File(filePath.child(pathToApp).getRemote());
+    private SymbolUploadBeginRequest appleSymbolsUpload(@Nonnull String pathToDebugSymbols) {
+        final File file = new File(filePath.child(pathToDebugSymbols).getRemote());
 
         return new SymbolUploadBeginRequest(Apple, null, file.getName(), "", "");
     }

--- a/src/main/java/io/jenkins/plugins/appcenter/util/RemoteFileUtils.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/util/RemoteFileUtils.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.Serializable;
+import java.util.HashMap;
 
 public class RemoteFileUtils implements Serializable {
 
@@ -16,7 +17,7 @@ public class RemoteFileUtils implements Serializable {
     private final FilePath filePath;
 
     @Nullable
-    private File file;
+    private HashMap<String,File> fileCache;
 
     @Inject
     RemoteFileUtils(@Nonnull final FilePath filePath) {
@@ -25,8 +26,13 @@ public class RemoteFileUtils implements Serializable {
 
     @Nonnull
     public File getRemoteFile(@Nonnull String pathToRemoteFile) {
+        if (fileCache == null) {
+            fileCache = new HashMap();
+        }
+        File file = fileCache.get(pathToRemoteFile);
         if (file == null) {
             file = new File(filePath.child(pathToRemoteFile).getRemote());
+            fileCache.put(pathToRemoteFile, file);
         }
 
         return file;

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
@@ -184,8 +184,8 @@ public class PrerequisitesTaskTest {
         final FilePath[] releaseNotes = {new FilePath(new File(pathToReleaseNotes))};
         given(mockFilePath.list(anyString())).willReturn(files, debugSymbols, releaseNotes);
         given(mockFilePath.child(anyString())).willReturn(mockFilePath);
-        given(mockFilePath.getRemote()).willReturn(pathToApp);
-        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "app.ipa", "", "");
+        given(mockFilePath.getRemote()).willReturn(pathToDebugSymbols);
+        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "symbols.zip", "", "");
         final UploadRequest expected = fullUploadRequest.newBuilder()
             .setPathToApp(pathToApp)
             .setPathToDebugSymbols(pathToDebugSymbols)
@@ -212,8 +212,8 @@ public class PrerequisitesTaskTest {
         final FilePath[] releaseNotes = {new FilePath(new File(pathToReleaseNotes))};
         given(mockFilePath.list(anyString())).willReturn(files, debugSymbols, releaseNotes);
         given(mockFilePath.child(anyString())).willReturn(mockFilePath);
-        given(mockFilePath.getRemote()).willReturn(pathToApp);
-        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "app.app.zip", "", "");
+        given(mockFilePath.getRemote()).willReturn(pathToDebugSymbols);
+        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "symbols.zip", "", "");
         final UploadRequest expected = fullUploadRequest.newBuilder()
             .setPathToApp(pathToApp)
             .setPathToDebugSymbols(pathToDebugSymbols)
@@ -240,8 +240,8 @@ public class PrerequisitesTaskTest {
         final FilePath[] releaseNotes = {new FilePath(new File(pathToReleaseNotes))};
         given(mockFilePath.list(anyString())).willReturn(files, debugSymbols, releaseNotes);
         given(mockFilePath.child(anyString())).willReturn(mockFilePath);
-        given(mockFilePath.getRemote()).willReturn(pathToApp);
-        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "app.pkg", "", "");
+        given(mockFilePath.getRemote()).willReturn(pathToDebugSymbols);
+        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "symbols.zip", "", "");
         final UploadRequest expected = fullUploadRequest.newBuilder()
             .setPathToApp(pathToApp)
             .setPathToDebugSymbols(pathToDebugSymbols)
@@ -268,8 +268,8 @@ public class PrerequisitesTaskTest {
         final FilePath[] releaseNotes = {new FilePath(new File(pathToReleaseNotes))};
         given(mockFilePath.list(anyString())).willReturn(files, debugSymbols, releaseNotes);
         given(mockFilePath.child(anyString())).willReturn(mockFilePath);
-        given(mockFilePath.getRemote()).willReturn(pathToApp);
-        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "app.dmg", "", "");
+        given(mockFilePath.getRemote()).willReturn(pathToDebugSymbols);
+        final SymbolUploadBeginRequest symbolUploadBeginRequest = new SymbolUploadBeginRequest(Apple, null, "symbols.zip", "", "");
         final UploadRequest expected = fullUploadRequest.newBuilder()
             .setPathToApp(pathToApp)
             .setPathToDebugSymbols(pathToDebugSymbols)

--- a/src/test/java/io/jenkins/plugins/appcenter/util/RemoteFileUtilsTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/util/RemoteFileUtilsTest.java
@@ -43,6 +43,33 @@ public class RemoteFileUtilsTest {
     }
 
     @Test
+    public void should_ReturnDifferentFiles_When_MultipleFileExists() {
+        // Given
+        final String TEST_PATH_2 = TEST_FILE_PATH+"2";
+        final File expected = new File(TEST_FILE_PATH);
+        final File expected2 = new File(TEST_PATH_2);
+        given(filePath.getRemote()).willReturn(TEST_FILE_PATH);
+
+        // When
+        final File remoteFile = remoteFileUtils.getRemoteFile(TEST_FILE_PATH);
+
+        // Then
+        assertThat(remoteFile).isEqualTo(expected);
+
+        // Given
+        given(filePath.getRemote()).willReturn(TEST_PATH_2);
+        // When
+        final File remoteFile2 = remoteFileUtils.getRemoteFile(TEST_PATH_2);
+        // Then
+        assertThat(remoteFile2).isEqualTo(expected2);
+
+        // When
+        final File firstFile = remoteFileUtils.getRemoteFile(TEST_FILE_PATH);
+        // Then
+        assertThat(firstFile).isEqualTo(expected);
+    }
+
+    @Test
     public void should_ReturnFileName_When_FileExists() {
         // Given
         given(filePath.getRemote()).willReturn(TEST_FILE_PATH);


### PR DESCRIPTION
This should fix the issue reported at https://issues.jenkins.io/browse/JENKINS-65285 .   Thanks to Thomas Innes for debugging it; this is mostly his suggested code fixes in the issue, with unit test fixes added.
