### PR TITLE
Removed 1 unnecessary stubbing in FinishReleaseTaskTest.java

### DIFF
--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/FinishReleaseTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/FinishReleaseTaskTest.java
@@ -54,51 +54,6 @@ public class FinishReleaseTaskTest {
     }
 
     @Test
-    public void should_ReturnException_When_UploadDomainIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("uploadDomain cannot be null");
-    }
-
-    @Test
-    public void should_ReturnException_When_PackageAssetIdIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .setUploadDomain("upload-domain")
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("packageAssetId cannot be null");
-    }
-
-    @Test
-    public void should_ReturnException_When_TokenIsMissing() {
-        // Given
-        final UploadRequest uploadRequest = baseRequest.newBuilder()
-            .setUploadDomain("upload-domain")
-            .setPackageAssetId("package_asset_id")
-            .build();
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
-
-        // Then
-        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
-        assertThat(exception).hasMessageThat().contains("token cannot be null");
-    }
-
-    @Test
     public void should_ReturnResponse_When_RequestIsSuccessful() throws Exception {
         // Given
         final UploadRequest uploadRequest = baseRequest.newBuilder()

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondFinishReleaseTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondFinishReleaseTaskTest.java
@@ -1,0 +1,87 @@
+package io.jenkins.plugins.appcenter.task.internal;
+
+import hudson.ProxyConfiguration;
+import hudson.model.TaskListener;
+import hudson.util.Secret;
+import io.jenkins.plugins.appcenter.AppCenterException;
+import io.jenkins.plugins.appcenter.api.AppCenterServiceFactory;
+import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SecondFinishReleaseTaskTest {
+
+    @Rule
+    public MockWebServer mockWebServer = new MockWebServer();
+
+    @Mock
+    TaskListener mockTaskListener;
+
+    @Mock
+    PrintStream mockLogger;
+
+    @Mock
+    ProxyConfiguration mockProxyConfig;
+
+    private UploadRequest baseRequest;
+
+    private FinishReleaseTask task;
+
+    @Before
+    public void setUp() {
+        baseRequest = new UploadRequest.Builder()
+                .setOwnerName("owner-name")
+                .setAppName("app-name")
+                .build();
+        final AppCenterServiceFactory factory = new AppCenterServiceFactory(Secret.fromString("secret-token"), mockWebServer.url("/").toString(), mockProxyConfig);
+        task = new FinishReleaseTask(mockTaskListener, factory);
+    }
+
+    @Test
+    public void should_ReturnException_When_UploadDomainIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("uploadDomain cannot be null");
+    }
+
+    @Test
+    public void should_ReturnException_When_PackageAssetIdIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().setUploadDomain("upload-domain").build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("packageAssetId cannot be null");
+    }
+
+    @Test
+    public void should_ReturnException_When_TokenIsMissing() {
+        // Given
+        final UploadRequest uploadRequest = baseRequest.newBuilder().setUploadDomain("upload-domain").setPackageAssetId("package_asset_id").build();
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(uploadRequest).get();
+        // Then
+        final NullPointerException exception = assertThrows(NullPointerException.class, throwingRunnable);
+        assertThat(exception).hasMessageThat().contains("token cannot be null");
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
In our analysis of the project, we observed that:
1 stubbing in `FinishReleaseTaskTest.setUp` is created but never executed by 3 tests `FinishReleaseTaskTest.should_ReturnException_When_UploadDomainIsMissing`, `FinishReleaseTaskTest.should_ReturnException_When_PackageAssetIdIsMissing`,` FinishReleaseTaskTest.should_ReturnException_When_TokenIsMissing`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.