### PR TITLE
Removed 1 unnecessary stubbing in PrerequisitesTaskTest.java

### DIFF
--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/PrerequisitesTaskTest.java
@@ -80,38 +80,6 @@ public class PrerequisitesTaskTest {
     }
 
     @Test
-    public void should_ThrowExecutionException_When_FileDoesNotExists() throws Exception {
-        // Given
-        final FilePath[] files = {};
-        given(mockFilePath.list(anyString())).willReturn(files);
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(fullUploadRequest).get();
-
-        // Then
-        final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
-        assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo(String.format("No file found matching pattern: %s", fullUploadRequest.pathToApp));
-    }
-
-    @Test
-    public void should_ThrowExecutionException_When_MultipleFilesExists() throws Exception {
-        // Given
-        final String pathToApp = "path/to/app.apk";
-        final String pathToAnotherApp = "path/to/sample.apk";
-        final FilePath[] files = {new FilePath(new File(pathToApp)), new FilePath(new File(pathToAnotherApp))};
-        given(mockFilePath.list(anyString())).willReturn(files);
-
-        // When
-        final ThrowingRunnable throwingRunnable = () -> task.execute(fullUploadRequest).get();
-
-        // Then
-        final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
-        assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
-        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo(String.format("Multiple files found matching pattern: %s", fullUploadRequest.pathToApp));
-    }
-
-    @Test
     public void should_ReturnModifiedRequest_When_DebugSymbolsExists_Android() throws Exception {
         // Given
         final String pathToApp = String.join(File.separator, "path", "to", "app.apk");

--- a/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondPrerequisitesTaskTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/task/internal/SecondPrerequisitesTaskTest.java
@@ -1,0 +1,85 @@
+package io.jenkins.plugins.appcenter.task.internal;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import io.jenkins.plugins.appcenter.AppCenterException;
+import io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest;
+import io.jenkins.plugins.appcenter.task.request.UploadRequest;
+import io.jenkins.plugins.appcenter.util.AndroidParser;
+import io.jenkins.plugins.appcenter.util.ParserFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest.SymbolTypeEnum.AndroidProguard;
+import static io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest.SymbolTypeEnum.Apple;
+import static io.jenkins.plugins.appcenter.model.appcenter.SymbolUploadBeginRequest.SymbolTypeEnum.Breakpad;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SecondPrerequisitesTaskTest {
+
+    @Mock
+    TaskListener mockTaskListener;
+
+    @Mock
+    PrintStream mockLogger;
+
+    @Mock
+    FilePath mockFilePath;
+
+    @Mock
+    ParserFactory mockParserFactory;
+
+    @Mock
+    AndroidParser mockAndroidParser;
+
+    private UploadRequest fullUploadRequest;
+
+    private PrerequisitesTask task;
+
+    @Before
+    public void setUp() {
+        fullUploadRequest = new UploadRequest.Builder().setPathToApp("path/to/app").setPathToDebugSymbols("path/to/debug-symbols").setPathToReleaseNotes("path/to/release-notes").build();
+        task = new PrerequisitesTask(mockTaskListener, mockFilePath, mockParserFactory);
+    }
+
+    @Test
+    public void should_ThrowExecutionException_When_FileDoesNotExists() throws Exception {
+        // Given
+        final FilePath[] files = {};
+        given(mockFilePath.list(anyString())).willReturn(files);
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(fullUploadRequest).get();
+        // Then
+        final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
+        assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
+        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo(String.format("No file found matching pattern: %s", fullUploadRequest.pathToApp));
+    }
+
+    @Test
+    public void should_ThrowExecutionException_When_MultipleFilesExists() throws Exception {
+        // Given
+        final String pathToApp = "path/to/app.apk";
+        final String pathToAnotherApp = "path/to/sample.apk";
+        final FilePath[] files = { new FilePath(new File(pathToApp)), new FilePath(new File(pathToAnotherApp)) };
+        given(mockFilePath.list(anyString())).willReturn(files);
+        // When
+        final ThrowingRunnable throwingRunnable = () -> task.execute(fullUploadRequest).get();
+        // Then
+        final ExecutionException exception = assertThrows(ExecutionException.class, throwingRunnable);
+        assertThat(exception).hasCauseThat().isInstanceOf(AppCenterException.class);
+        assertThat(exception).hasCauseThat().hasMessageThat().isEqualTo(String.format("Multiple files found matching pattern: %s", fullUploadRequest.pathToApp));
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

In our analysis of the project, we observed that:
1 stubbing is created but never executed by 2 test `PrerequisitesTaskTest.should_ThrowExecutionException_When_FileDoesNotExists`, `PrerequisitesTaskTest.should_ThrowExecutionException_When_MultipleFilesExists`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.
